### PR TITLE
Add missing build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@ node_modules
 cypress/downloads
 cypress/screenshots
 cypress/videos
+
+# Ignore all dist files except for the CustomTourBuilder
+dist/*
+!dist/CustomTourBuilder.js

--- a/dist/CustomTourBuilder.js
+++ b/dist/CustomTourBuilder.js
@@ -1,125 +1,188 @@
-import t, { useState as c, useEffect as g } from "react";
-const b = (s) => {
-  const [e, l] = c(null), [r, n] = c(!1), [i, o] = c(null);
-  return g(() => {
-    const a = new URL("https://api.artic.edu/api/v1/artworks/search");
-    a.searchParams.set("query[bool][must][][term][is_on_view]", "true"), a.searchParams.set(
+import r, { useState as o, useEffect as p, createContext as b, useContext as g } from "react";
+import e from "prop-types";
+const R = (a) => {
+  const [n, c] = o(null), [t, i] = o(!1), [u, m] = o(null);
+  return p(() => {
+    const s = new URL("https://api.artic.edu/api/v1/artworks/search");
+    s.searchParams.set("query[bool][must][][term][is_on_view]", "true"), s.searchParams.set(
       "query[bool][must][][exists][field]",
       "description"
-    ), a.searchParams.set(
+    ), s.searchParams.set(
       "query[bool][should][][exists][field]",
       "description"
-    ), a.searchParams.set(
+    ), s.searchParams.set(
       "query[bool][should][][exists][field]",
       "subject_id"
-    ), a.searchParams.set("query[bool][should][][exists][field]", "style_id"), a.searchParams.set("query[bool][should][][term][is_boosted]", "true"), a.searchParams.set("query[bool][minimum_should_match]", "1"), a.searchParams.set("fields", "true"), a.searchParams.set("limit", "10"), a.searchParams.set("q", s);
-    const h = new AbortController(), u = h.signal;
-    if (s === "") {
-      l(null), n(!1), o(null);
+    ), s.searchParams.set("query[bool][should][][exists][field]", "style_id"), s.searchParams.set("query[bool][should][][term][is_boosted]", "true"), s.searchParams.set("query[bool][minimum_should_match]", "1"), s.searchParams.set("fields", "true"), s.searchParams.set("limit", "10"), s.searchParams.set("q", a);
+    const h = new AbortController(), d = h.signal;
+    if (a === "") {
+      c(null), i(!1), m(null);
       return;
     }
-    async function d() {
+    async function f() {
       try {
-        const E = await (await fetch(a, { signal: u })).json();
-        l(E), n(!1);
-      } catch (f) {
-        if (f.name === "AbortError")
+        const _ = await (await fetch(s, { signal: d })).json();
+        c(_), i(!1);
+      } catch (l) {
+        if (l.name === "AbortError")
           return;
-        o(f.message), n(!1);
+        m("Error fetching results"), i(!1);
       }
     }
-    return n(!0), d(), () => {
+    return i(!0), f(), () => {
       h.abort();
     };
-  }, [s]), { data: e, error: i, fetching: r };
-};
-function p(s) {
+  }, [a]), { data: n, error: u, fetching: t };
+}, y = b();
+function S(a) {
   const {
-    searchQuery: e,
-    setSearchQuery: l,
-    setSearchResultItems: r,
-    setSearchError: n,
-    setSearchFetching: i,
-    setIiifBaseUrl: o
-  } = s, [a, h] = c(""), { data: u, error: d, fetching: f } = b(e), E = (m) => {
-    l(a), m.preventDefault();
+    children: n,
+    searchResultItems: c,
+    searchQuery: t,
+    searchFetching: i,
+    searchError: u
+  } = a, [m, s] = o(
+    c || null
+  ), [h, d] = o(t || ""), [f, l] = o(
+    i || !1
+  ), [_, q] = o(u || !1);
+  return /* @__PURE__ */ r.createElement(
+    y.Provider,
+    {
+      value: {
+        searchResultItems: m,
+        setSearchResultItems: s,
+        searchQuery: h,
+        setSearchQuery: d,
+        searchFetching: f,
+        setSearchFetching: l,
+        searchError: _,
+        setSearchError: q
+      }
+    },
+    n
+  );
+}
+S.propTypes = {
+  children: e.node.isRequired,
+  searchResultItems: e.array,
+  searchQuery: e.string,
+  searchFetching: e.bool,
+  searchError: e.oneOfType([e.string, e.bool])
+};
+y.Provider.propTypes = {
+  value: e.shape({
+    searchResultItems: e.array,
+    setSearchResultItems: e.func,
+    searchQuery: e.string,
+    setSearchQuery: e.func,
+    searchFetching: e.bool,
+    setSearchFetching: e.func,
+    searchError: e.oneOfType([e.string, e.bool]),
+    setSearchError: e.func
+  }),
+  children: e.node.isRequired
+};
+function F() {
+  const {
+    searchQuery: a,
+    setSearchQuery: n,
+    setSearchResultItems: c,
+    setSearchError: t,
+    setSearchFetching: i
+  } = g(y), [u, m] = o(""), { data: s, error: h, fetching: d } = R(a), f = (l) => {
+    n(u), l.preventDefault();
   };
-  return g(() => {
-    u && (r(u.data), o(u.config.iiif_url));
-  }, [u, r, o]), g(() => {
-    n(d);
-  }, [d, n]), g(() => {
-    i(f);
-  }, [f, i]), /* @__PURE__ */ t.createElement(
+  return p(() => {
+    s && c(s.data);
+  }, [s, c]), p(() => {
+    t(h);
+  }, [h, t]), p(() => {
+    i(d);
+  }, [d, i]), /* @__PURE__ */ r.createElement(
     "form",
     {
+      id: "aic-ct-search",
       role: "search",
       "aria-label": "Objects for your tour",
-      onSubmit: E
+      onSubmit: f
     },
-    /* @__PURE__ */ t.createElement(
+    /* @__PURE__ */ r.createElement("label", { htmlFor: "aic-ct-search__input", className: "sr-only" }, "Search the collection"),
+    /* @__PURE__ */ r.createElement(
       "input",
       {
+        id: "aic-ct-search__input",
         type: "search",
         placeholder: "Search",
-        onChange: (m) => {
-          m.target.value && m.target.setCustomValidity(""), h(m.target.value);
+        onChange: (l) => {
+          l.target.value && l.target.setCustomValidity(""), m(l.target.value);
         },
-        onInvalid: (m) => {
-          m.target.setCustomValidity("You must enter a search term");
+        onInvalid: (l) => {
+          l.target.setCustomValidity("You must enter a search term");
         },
         required: !0
       }
     ),
-    /* @__PURE__ */ t.createElement("button", { type: "submit" }, "Search")
+    /* @__PURE__ */ r.createElement("button", { id: "aic-ct-search__button", type: "submit" }, "Search")
   );
 }
-function y(s, e, l = "", r = "", n = "full", i = !0) {
-  return `${s}/${e}/${n}/${i && "!"}${l},${r}/0/default.jpg`;
+function x(a, n, c = "", t = "", i = "full", u = !0) {
+  return `${a}/${n}/${i}/${u && "!"}${c},${t}/0/default.jpg`;
 }
-function S(s) {
-  const { item: e, iiifBaseUrl: l } = s;
-  return /* @__PURE__ */ t.createElement("li", null, e.title && /* @__PURE__ */ t.createElement("h2", null, e.title), e.image_id && /* @__PURE__ */ t.createElement(
+const E = b();
+function v({ children: a }) {
+  return /* @__PURE__ */ r.createElement(
+    E.Provider,
+    {
+      value: {
+        iiifBaseUrl: "https://artic.edu/iiif/2"
+      }
+    },
+    a
+  );
+}
+v.propTypes = {
+  children: e.node.isRequired
+};
+E.Provider.propTypes = {
+  value: e.shape({
+    iiifBaseUrl: e.string
+  })
+};
+function P(a) {
+  const { iiifBaseUrl: n } = g(E), { id: c, item: t } = a;
+  return /* @__PURE__ */ r.createElement("li", { id: `aic-ct-search__item-${c}` }, t.title && /* @__PURE__ */ r.createElement("h2", null, t.title), t.image_id && /* @__PURE__ */ r.createElement(
     "img",
     {
-      src: y(l, e.image_id, "240", "240"),
-      alt: e.thumbnail.alt_text
+      src: x(n, t.image_id, "240", "240"),
+      alt: t.thumbnail.alt_text
     }
-  ), e.artist_title && /* @__PURE__ */ t.createElement("p", null, e.artist_title), e.description && /* @__PURE__ */ t.createElement("div", { dangerouslySetInnerHTML: { __html: e.description } }));
+  ), t.artist_title && /* @__PURE__ */ r.createElement("p", null, t.artist_title), t.description && /* @__PURE__ */ r.createElement("div", { dangerouslySetInnerHTML: { __html: t.description } }));
 }
-function _(s) {
-  const { searchError: e, searchFetching: l, searchResultItems: r, iiifBaseUrl: n } = s;
-  return l ? /* @__PURE__ */ t.createElement("div", null, "Loading...") : e ? /* @__PURE__ */ t.createElement("div", null, e) : (r == null ? void 0 : r.length) === 0 ? /* @__PURE__ */ t.createElement("div", null, "No results found") : (r == null ? void 0 : r.length) > 0 ? /* @__PURE__ */ t.createElement("ul", null, r.map((i) => /* @__PURE__ */ t.createElement(
-    S,
+P.propTypes = {
+  id: e.string.isRequired,
+  item: e.shape({
+    title: e.string.isRequired,
+    image_id: e.string,
+    thumbnail: e.shape({
+      alt_text: e.string
+    }),
+    artist_title: e.string,
+    description: e.string
+  })
+};
+function C() {
+  const { iiifBaseUrl: a } = g(E), { searchError: n, searchFetching: c, searchResultItems: t } = g(y);
+  return c ? /* @__PURE__ */ r.createElement("div", { id: "aic-ct-search__loading" }, "Loading...") : n ? /* @__PURE__ */ r.createElement("div", { id: "aic-ct-search__error" }, n) : (t == null ? void 0 : t.length) === 0 ? /* @__PURE__ */ r.createElement("div", { id: "aic-ct-search__no-results" }, "Sorry, we couldn’t find any results matching your criteria") : (t == null ? void 0 : t.length) > 0 ? /* @__PURE__ */ r.createElement("ul", { id: "aic-ct-search__results" }, t.map((i) => /* @__PURE__ */ r.createElement(
+    P,
     {
       key: i.id,
       item: i,
-      iiifBaseUrl: n
+      iiifBaseUrl: a
     }
   ))) : null;
 }
-const P = () => {
-  const [s, e] = c(null), [l, r] = c(""), [n, i] = c(!1), [o, a] = c(null), [h, u] = c("");
-  return /* @__PURE__ */ t.createElement(t.Fragment, null, /* @__PURE__ */ t.createElement(
-    p,
-    {
-      searchQuery: l,
-      setSearchQuery: r,
-      setSearchFetching: i,
-      setSearchError: a,
-      setSearchResultItems: e,
-      setIiifBaseUrl: u
-    }
-  ), /* @__PURE__ */ t.createElement(
-    _,
-    {
-      searchError: o,
-      searchFetching: n,
-      searchResultItems: s,
-      iiifBaseUrl: h
-    }
-  ));
-};
+const Q = () => /* @__PURE__ */ r.createElement(v, null, /* @__PURE__ */ r.createElement(S, null, /* @__PURE__ */ r.createElement(F, null), /* @__PURE__ */ r.createElement(C, null)));
 export {
-  P as default
+  Q as default
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "custom-tours",
       "version": "0.1.0",
       "license": "GNU Affero General Public License v3.0",
+      "dependencies": {
+        "prop-types": "^15.8.1"
+      },
       "devDependencies": {
         "@types/react": "^16.9.0",
         "@types/react-dom": "^16.9.0",
@@ -21,7 +24,6 @@
         "eslint-plugin-react-hooks": "^4.6.0",
         "npm-run-all": "^4.1.5",
         "prettier": "^3.0.0",
-        "prop-types": "^15.8.1",
         "react": "^16.9.0",
         "react-dom": "^16.9.0",
         "vite": "^4.4.5"
@@ -4065,8 +4067,7 @@
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "node_modules/js-yaml": {
       "version": "4.1.0",
@@ -4475,7 +4476,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       },
@@ -4768,7 +4768,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5199,7 +5198,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -5310,8 +5308,7 @@
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/react-refresh": {
       "version": "0.14.0",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,9 @@
     "test": "cypress run --component --port=3000",
     "test:gui": "cypress open --component --port=3000"
   },
+  "dependencies": {
+    "prop-types": "^15.8.1"
+  },
   "peerDependencies": {
     "react": "^16.9.0",
     "react-dom": "^16.9.0"
@@ -32,7 +35,6 @@
     "eslint-plugin-react-hooks": "^4.6.0",
     "npm-run-all": "^4.1.5",
     "prettier": "^3.0.0",
-    "prop-types": "^15.8.1",
     "react": "^16.9.0",
     "react-dom": "^16.9.0",
     "vite": "^4.4.5"

--- a/vite.config.js
+++ b/vite.config.js
@@ -12,7 +12,7 @@ export default defineConfig({
     },
     rollupOptions: {
       // We don't want to bundle React with our code, so we mark it as external
-      external: ["react", "react-dom", "react/jsx-runtime"],
+      external: ["react", "react-dom", "react/jsx-runtime", "prop-types"],
       output: {
         entryFileNames: `[name].js`,
         chunkFileNames: `[name].js`,
@@ -21,6 +21,7 @@ export default defineConfig({
           react: "react",
           "react-dom": "ReactDOM",
           "react/jsx-runtime": "react/jsx-runtime",
+          "prop-types": "PropTypes",
         },
       },
     },


### PR DESCRIPTION
This was necessary because the bundle from the previous PR was stale and needed updating, but also addresses some other mistakes, namely:
- `prop-types` should not have been a `devDependency`
- `PropTypes` imports were creating a huge bundle (seemingly by bringing in its own version of React), and needed to be excluded
- Some dist files don't need to be tracked and were added to the `.gitignore` file