### PR TITLE
Add theme search controls

### DIFF
--- a/dist/CustomTourBuilder.js
+++ b/dist/CustomTourBuilder.js
@@ -1,4 +1,4 @@
-import t, { createContext as x, useState as h, useReducer as H, useRef as A, useMemo as D, useContext as E, useEffect as y } from "react";
+import t, { createContext as x, useState as p, useReducer as H, useRef as A, useMemo as D, useContext as E, useEffect as y } from "react";
 import r from "prop-types";
 const z = (n, e) => {
   switch (e.type) {
@@ -11,7 +11,7 @@ const z = (n, e) => {
     default:
       return n;
   }
-}, I = x();
+}, S = x();
 function F(n) {
   const {
     children: e,
@@ -20,12 +20,12 @@ function F(n) {
     tourItems: i,
     navPages: s,
     apiSaveEndpoint: c
-  } = n, [u, d] = h(a || ""), [p, m] = h(
+  } = n, [u, d] = p(a || ""), [m, h] = p(
     l || ""
-  ), [f, o] = h(s || []), [g, v] = h(0), [b, S] = H(
+  ), [f, o] = p(s || []), [g, b] = p(0), [v, I] = H(
     z,
     i || []
-  ), _ = A(null), [R, $] = h([]), B = "https://artic.edu/iiif/2", L = c || "/api/v1/custom-tours", [Q, U] = h(!1), Y = D(
+  ), _ = A(null), [R, $] = p([]), B = "https://artic.edu/iiif/2", L = c || "/api/v1/custom-tours", [Q, U] = p(!1), Y = D(
     () => ({
       note: 255,
       title: 255,
@@ -38,7 +38,7 @@ function F(n) {
     []
   );
   return /* @__PURE__ */ t.createElement(
-    I.Provider,
+    S.Provider,
     {
       value: {
         apiSaveEndpoint: L,
@@ -46,14 +46,14 @@ function F(n) {
         limits: Y,
         tourTitle: u,
         setTourTitle: d,
-        tourDescription: p,
-        setTourDescription: m,
-        tourItems: b,
-        tourItemsDispatch: S,
+        tourDescription: m,
+        setTourDescription: h,
+        tourItems: v,
+        tourItemsDispatch: I,
         navPages: f,
         setNavPages: o,
         activeNavPage: g,
-        setActiveNavPage: v,
+        setActiveNavPage: b,
         navSearchButtonRef: _,
         validityIssues: R,
         setValidityIssues: $,
@@ -72,7 +72,7 @@ F.propTypes = {
   tourItems: r.instanceOf(Array),
   navPages: r.instanceOf(Array)
 };
-I.Provider.propTypes = {
+S.Provider.propTypes = {
   value: r.shape({
     apiSaveEndpoint: r.string,
     iiifBaseUrl: r.string,
@@ -111,7 +111,7 @@ function J() {
     setActiveNavPage: a,
     navSearchButtonRef: l,
     isSaving: i
-  } = E(I);
+  } = E(S);
   return /* @__PURE__ */ t.createElement("nav", { id: "aic-ct-navigation", "aria-label": "Custom tour navigation" }, n.map((s, c) => /* @__PURE__ */ t.createElement(
     "button",
     {
@@ -128,7 +128,7 @@ function J() {
   )));
 }
 function w({ children: n }) {
-  const { setNavPages: e } = E(I);
+  const { setNavPages: e } = E(S);
   return y(() => {
     e(
       n ? n.map((a, l) => ({
@@ -142,7 +142,7 @@ w.propTypes = {
   children: r.node.isRequired
 };
 function P(n) {
-  const { id: e, children: a } = n, { activeNavPage: l } = E(I);
+  const { id: e, children: a } = n, { activeNavPage: l } = E(S);
   return /* @__PURE__ */ t.createElement(
     "div",
     {
@@ -171,11 +171,11 @@ function k(n) {
     searchQuery: l,
     searchFetching: i,
     searchError: s
-  } = n, [c, u] = h(
+  } = n, [c, u] = p(
     a || null
-  ), [d, p] = h(l || ""), [m, f] = h(
+  ), [d, m] = p(l || ""), [h, f] = p(
     i || !1
-  ), [o, g] = h(s || !1), [v, b] = h(null);
+  ), [o, g] = p(s || !1), [b, v] = p(null);
   return /* @__PURE__ */ t.createElement(
     T.Provider,
     {
@@ -183,13 +183,13 @@ function k(n) {
         searchResultItems: c,
         setSearchResultItems: u,
         searchQuery: d,
-        setSearchQuery: p,
-        searchFetching: m,
+        setSearchQuery: m,
+        searchFetching: h,
         setSearchFetching: f,
         searchError: o,
         setSearchError: g,
-        activeTheme: v,
-        setActiveTheme: b
+        activeTheme: b,
+        setActiveTheme: v
       }
     },
     e
@@ -218,15 +218,15 @@ T.Provider.propTypes = {
   children: r.node.isRequired
 };
 const q = (n) => {
-  const [e, a] = h(null), [l, i] = h(!1), [s, c] = h(null), [u, d] = h(null), { dataSubSelector: p, dataSetter: m, fetchingSetter: f, errorSetter: o } = n || {}, g = () => {
+  const [e, a] = p(null), [l, i] = p(!1), [s, c] = p(null), [u, d] = p(null), { dataSubSelector: m, dataSetter: h, fetchingSetter: f, errorSetter: o } = n || {}, g = () => {
     a(null), i(!1), c(null), d(null);
-  }, v = async (b) => {
+  }, b = async (v) => {
     i(!0);
-    const S = new AbortController();
-    d(S);
+    const I = new AbortController();
+    d(I);
     try {
-      const R = await (await fetch(b, { signal: S.signal })).json();
-      a(p ? R[p] : R), c(null), i(!1);
+      const R = await (await fetch(v, { signal: I.signal })).json();
+      a(m ? R[m] : R), c(null), i(!1);
     } catch (_) {
       if (_.name === "AbortError") {
         g();
@@ -236,17 +236,17 @@ const q = (n) => {
     }
   };
   return y(() => {
-    const b = u;
+    const v = u;
     return () => {
-      b && b.abort();
+      v && v.abort();
     };
   }, [u]), y(() => {
-    m && m(e);
-  }, [e, m]), y(() => {
+    h && h(e);
+  }, [e, h]), y(() => {
     o && o(s);
   }, [s, o]), y(() => {
     f && f(l);
-  }, [l, f]), { data: e, fetching: l, error: s, fetchData: v, resetState: g };
+  }, [l, f]), { data: e, fetching: l, error: s, fetchData: b, resetState: g };
 };
 function N(n, e, a = "", l = "", i = "full", s = !0) {
   return `${n}/${e}/${i}/${s && "!"}${a},${l}/0/default.jpg`;
@@ -310,26 +310,26 @@ function G() {
   );
 }
 function V(n) {
-  const { id: e, label: a, subjectIds: l, thumbnailId: i, categoryIds: s } = n, {
-    setSearchResultItems: c,
-    setSearchFetching: u,
-    setSearchError: d,
-    setSearchQuery: p,
+  const { id: e, label: a, subjectIds: l, categoryIds: i } = n, {
+    setSearchResultItems: s,
+    setSearchFetching: c,
+    setSearchError: u,
+    setSearchQuery: d,
     activeTheme: m,
-    setActiveTheme: f
-  } = E(T), { fetchData: o, resetState: g } = q({
+    setActiveTheme: h
+  } = E(T), { fetchData: f, resetState: o } = q({
     dataSubSelector: "data",
-    dataSetter: c,
-    fetchingSetter: u,
-    errorSetter: d
-  }), v = () => {
-    m === a ? (f(null), g()) : (o(O({ subjectIds: l, categoryIds: s })), f(a), p(""));
+    dataSetter: s,
+    fetchingSetter: c,
+    errorSetter: u
+  }), g = () => {
+    m === a ? (h(null), o()) : (f(O({ subjectIds: l, categoryIds: i })), h(a), d(""));
   };
   return /* @__PURE__ */ t.createElement(t.Fragment, null, (m === null || m === a) && /* @__PURE__ */ t.createElement(
     "button",
     {
       id: `aic-ct-theme-toggle-${e}`,
-      onClick: v,
+      onClick: g,
       "aria-pressed": m === a ? "true" : "false"
     },
     a
@@ -388,7 +388,7 @@ function K() {
   )));
 }
 function j(n) {
-  const { iiifBaseUrl: e, tourItems: a, tourItemsDispatch: l } = E(I), { itemData: i } = n, [s, c] = h(!1), u = () => {
+  const { iiifBaseUrl: e, tourItems: a, tourItemsDispatch: l } = E(S), { itemData: i } = n, [s, c] = p(!1), u = () => {
     l({
       type: s ? "REMOVE_ITEM" : "ADD_ITEM",
       payload: s ? i.id : i
@@ -430,7 +430,7 @@ function W() {
   return e ? /* @__PURE__ */ t.createElement("div", { id: "aic-ct-search__loading" }, "Loading...") : n ? /* @__PURE__ */ t.createElement("div", { id: "aic-ct-search__error" }, n) : (a == null ? void 0 : a.length) === 0 ? /* @__PURE__ */ t.createElement("div", { id: "aic-ct-search__no-results" }, "Sorry, we couldn’t find any results matching your criteria") : (a == null ? void 0 : a.length) > 0 ? /* @__PURE__ */ t.createElement("ul", { id: "aic-ct-search__results" }, a.map((l) => /* @__PURE__ */ t.createElement(j, { key: l.id, itemData: l }))) : null;
 }
 function C(n, e) {
-  const [a, l] = h(n || ""), i = A(null);
+  const [a, l] = p(n || ""), i = A(null);
   return {
     value: a,
     onChange: (c) => {
@@ -444,12 +444,12 @@ function C(n, e) {
 }
 function M(n) {
   var g;
-  const { itemData: e, itemIndex: a, setShouldAssignFocus: l, setRemoveButtons: i } = n, { iiifBaseUrl: s, tourItems: c, tourItemsDispatch: u, limits: d } = E(I), p = A(null), m = C((g = c[a]) == null ? void 0 : g.note, d.note), f = D(
+  const { itemData: e, itemIndex: a, setShouldAssignFocus: l, setRemoveButtons: i } = n, { iiifBaseUrl: s, tourItems: c, tourItemsDispatch: u, limits: d } = E(S), m = A(null), h = C((g = c[a]) == null ? void 0 : g.note, d.note), f = D(
     () => ({
       id: e.id,
-      note: m.value
+      note: h.value
     }),
-    [e.id, m.value]
+    [e.id, h.value]
   ), o = () => {
     u({
       type: "REMOVE_ITEM",
@@ -462,21 +462,21 @@ function M(n) {
       payload: f
     });
   }, [f, u]), y(() => {
-    const v = p.current;
+    const b = m.current;
     return () => {
-      document.activeElement === v && (c.length > 1 ? c.find((b, S) => {
-        b.id === e.id && l({
+      document.activeElement === b && (c.length > 1 ? c.find((v, I) => {
+        v.id === e.id && l({
           flag: !0,
-          id: c[S !== c.length - 1 ? S + 1 : S - 1].id
+          id: c[I !== c.length - 1 ? I + 1 : I - 1].id
         });
       }) : l({
         flag: !0,
         id: null
       }));
     };
-  }, [c, e.id, l]), y(() => (i((v) => [...v, { id: e.id, ref: p }]), () => {
+  }, [c, e.id, l]), y(() => (i((b) => [...b, { id: e.id, ref: m }]), () => {
     i(
-      (v) => v.filter((b) => b.id !== e.id)
+      (b) => b.filter((v) => v.id !== e.id)
     );
   }), [i, c, e.id]), /* @__PURE__ */ t.createElement("li", { id: `aic-ct-tour__item-${e.id}` }, e.title && /* @__PURE__ */ t.createElement("h2", null, e.title), e.image_id && /* @__PURE__ */ t.createElement(
     "img",
@@ -484,19 +484,19 @@ function M(n) {
       src: N(s, e.image_id, "240", "240"),
       alt: e.thumbnail.alt_text
     }
-  ), e.artist_title && /* @__PURE__ */ t.createElement("p", null, e.artist_title), e.description && /* @__PURE__ */ t.createElement("div", { dangerouslySetInnerHTML: { __html: e.description } }), /* @__PURE__ */ t.createElement("label", { htmlFor: `aic-ct-note-${e.id}` }, "Personal note", " ", /* @__PURE__ */ t.createElement("span", { ref: m.countRef, "aria-live": "polite" }, "(", m.charsRemaining, /* @__PURE__ */ t.createElement("span", { className: "sr-only" }, " characters remaining"), ")")), /* @__PURE__ */ t.createElement("br", null), /* @__PURE__ */ t.createElement(
+  ), e.artist_title && /* @__PURE__ */ t.createElement("p", null, e.artist_title), e.description && /* @__PURE__ */ t.createElement("div", { dangerouslySetInnerHTML: { __html: e.description } }), /* @__PURE__ */ t.createElement("label", { htmlFor: `aic-ct-note-${e.id}` }, "Personal note", " ", /* @__PURE__ */ t.createElement("span", { ref: h.countRef, "aria-live": "polite" }, "(", h.charsRemaining, /* @__PURE__ */ t.createElement("span", { className: "sr-only" }, " characters remaining"), ")")), /* @__PURE__ */ t.createElement("br", null), /* @__PURE__ */ t.createElement(
     "textarea",
     {
       id: `aic-ct-note-${e.id}`,
-      onChange: m.onChange,
+      onChange: h.onChange,
       rows: "5",
-      value: m.value,
-      maxLength: m.maxLength
+      value: h.value,
+      maxLength: h.maxLength
     }
   ), /* @__PURE__ */ t.createElement("br", null), /* @__PURE__ */ t.createElement(
     "button",
     {
-      ref: p,
+      ref: m,
       type: "button",
       onClick: () => {
         o(e.id);
@@ -521,10 +521,10 @@ M.propTypes = {
   setShouldAssignFocus: r.func
 };
 function X() {
-  const { tourItems: n, navSearchButtonRef: e } = E(I), [a, l] = h({
+  const { tourItems: n, navSearchButtonRef: e } = E(S), [a, l] = p({
     flag: !1,
     id: null
-  }), [i, s] = h([]);
+  }), [i, s] = p([]);
   return y(() => {
     a.flag && (!n.length && (e != null && e.current) ? e.current.focus() : i.find((c) => c.id === a.id).ref.current.focus(), l(!1));
   }, [n, a, i, e]), /* @__PURE__ */ t.createElement(t.Fragment, null, n.length > 0 ? /* @__PURE__ */ t.createElement(t.Fragment, null, /* @__PURE__ */ t.createElement("h2", { id: "aic-ct-tour__heading" }, "Your tour"), /* @__PURE__ */ t.createElement("ul", { id: "aic-ct-tour__results" }, n.map((c, u) => /* @__PURE__ */ t.createElement(
@@ -546,7 +546,7 @@ function Z() {
     tourDescription: a,
     setTourDescription: l,
     limits: i
-  } = E(I), s = C(n, i.title), c = C(a, i.description);
+  } = E(S), s = C(n, i.title), c = C(a, i.description);
   return y(() => {
     e(s.value);
   }, [s, e]), y(() => {
@@ -583,7 +583,7 @@ function ee() {
     limits: c,
     isSaving: u,
     setIsSaving: d
-  } = E(I), [p, m] = h(null), f = async () => {
+  } = E(S), [m, h] = p(null), f = async () => {
     d(!0);
     try {
       const o = await fetch(`${n}`, {
@@ -596,9 +596,9 @@ function ee() {
           title: e,
           description: l,
           // Pass in note as objectNote and destructure the rest as rest
-          artworks: a.map(({ note: v, ...b }) => ({
-            objectNote: v,
-            ...b
+          artworks: a.map(({ note: b, ...v }) => ({
+            objectNote: b,
+            ...v
           }))
         })
       });
@@ -607,12 +607,12 @@ function ee() {
           "There was a problem saving your tour, please try again. If the problem persists, please contact us and let us know."
         );
       const { message: g } = await o.json();
-      m({
+      h({
         type: "success",
         message: g
       });
     } catch (o) {
-      m({
+      h({
         type: "error",
         message: o.message
       });
@@ -624,7 +624,7 @@ function ee() {
     e.length || o.push("A title is required"), e.length > c.title && o.push("Tour title must not exceed the character limit"), l.length > c.description && o.push(
       "Tour description must not exceed the character limit"
     ), a.length < c.items.min && o.push("At least one item is required"), a.length > c.items.max && o.push("Tours must not contain more than 6 artworks"), a.some((g) => g.note.length > c.note ? (o.push("Notes must not exceed the character limit"), !0) : !1), s(o);
-  }, [e, l, a, s, c]), /* @__PURE__ */ t.createElement(t.Fragment, null, /* @__PURE__ */ t.createElement("h2", null, "Submit your tour"), i.length ? /* @__PURE__ */ t.createElement(t.Fragment, null, /* @__PURE__ */ t.createElement("p", null, "Fix these issue before submitting your tour:"), i.length && /* @__PURE__ */ t.createElement("ul", { id: "aic-ct-validation-errors" }, i.map((o, g) => /* @__PURE__ */ t.createElement("li", { key: g }, o)))) : /* @__PURE__ */ t.createElement("div", { id: "aic-ct-validation-success" }, /* @__PURE__ */ t.createElement("div", { tabIndex: "-1", "aria-live": "polite" }, u && /* @__PURE__ */ t.createElement("p", null, "Saving..."), !u && !p && /* @__PURE__ */ t.createElement(t.Fragment, null, /* @__PURE__ */ t.createElement("p", null, "Are you sure you want to submit your tour? You won't be able to make any more changes after this stage"), /* @__PURE__ */ t.createElement(
+  }, [e, l, a, s, c]), /* @__PURE__ */ t.createElement(t.Fragment, null, /* @__PURE__ */ t.createElement("h2", null, "Submit your tour"), i.length ? /* @__PURE__ */ t.createElement(t.Fragment, null, /* @__PURE__ */ t.createElement("p", null, "Fix these issue before submitting your tour:"), i.length && /* @__PURE__ */ t.createElement("ul", { id: "aic-ct-validation-errors" }, i.map((o, g) => /* @__PURE__ */ t.createElement("li", { key: g }, o)))) : /* @__PURE__ */ t.createElement("div", { id: "aic-ct-validation-success" }, /* @__PURE__ */ t.createElement("div", { tabIndex: "-1", "aria-live": "polite" }, u && /* @__PURE__ */ t.createElement("p", null, "Saving..."), !u && !m && /* @__PURE__ */ t.createElement(t.Fragment, null, /* @__PURE__ */ t.createElement("p", null, "Are you sure you want to submit your tour? You won't be able to make any more changes after this stage"), /* @__PURE__ */ t.createElement(
     "button",
     {
       id: "aic-ct-save-button",
@@ -633,7 +633,7 @@ function ee() {
       disabled: u
     },
     "Save my tour"
-  )), p && (p.type === "success" && /* @__PURE__ */ t.createElement("div", { id: "aic-ct-save-success" }, /* @__PURE__ */ t.createElement("p", null, p.message)) || p.type === "error" && /* @__PURE__ */ t.createElement("div", { id: "aic-ct-save-error" }, /* @__PURE__ */ t.createElement("p", null, p.message), /* @__PURE__ */ t.createElement(
+  )), m && (m.type === "success" && /* @__PURE__ */ t.createElement("div", { id: "aic-ct-save-success" }, /* @__PURE__ */ t.createElement("p", null, m.message)) || m.type === "error" && /* @__PURE__ */ t.createElement("div", { id: "aic-ct-save-error" }, /* @__PURE__ */ t.createElement("p", null, m.message), /* @__PURE__ */ t.createElement(
     "button",
     {
       id: "aic-ct-save-button",

--- a/dist/CustomTourBuilder.js
+++ b/dist/CustomTourBuilder.js
@@ -1,31 +1,31 @@
-import e, { createContext as x, useState as h, useReducer as U, useRef as P, useMemo as C, useContext as E, useEffect as _ } from "react";
-import t from "prop-types";
-const j = (i, r) => {
-  switch (r.type) {
+import t, { createContext as x, useState as h, useReducer as H, useRef as A, useMemo as D, useContext as E, useEffect as y } from "react";
+import r from "prop-types";
+const z = (n, e) => {
+  switch (e.type) {
     case "ADD_ITEM":
-      return [...i, { ...r.payload, note: "" }];
+      return [...n, { ...e.payload, note: "" }];
     case "UPDATE_NOTE":
-      return i.map((a) => a.id === r.payload.id ? { ...a, note: r.payload.note } : a);
+      return n.map((a) => a.id === e.payload.id ? { ...a, note: e.payload.note } : a);
     case "REMOVE_ITEM":
-      return i.filter(({ id: a }) => a !== r.payload);
+      return n.filter(({ id: a }) => a !== e.payload);
     default:
-      return i;
+      return n;
   }
-}, y = x();
-function D(i) {
+}, I = x();
+function F(n) {
   const {
-    children: r,
+    children: e,
     tourTitle: a,
-    tourDescription: o,
-    tourItems: n,
+    tourDescription: l,
+    tourItems: i,
     navPages: s,
-    apiSaveEndpoint: l
-  } = i, [d, g] = h(a || ""), [u, c] = h(
-    o || ""
-  ), [f, m] = h(s || []), [p, v] = h(0), [b, T] = U(
-    j,
-    n || []
-  ), V = P(null), [O, k] = h([]), $ = "https://artic.edu/iiif/2", B = l || "/api/v1/custom-tours", [M, L] = h(!1), Q = C(
+    apiSaveEndpoint: c
+  } = n, [u, d] = h(a || ""), [p, m] = h(
+    l || ""
+  ), [f, o] = h(s || []), [g, v] = h(0), [b, S] = H(
+    z,
+    i || []
+  ), _ = A(null), [R, $] = h([]), B = "https://artic.edu/iiif/2", L = c || "/api/v1/custom-tours", [Q, U] = h(!1), Y = D(
     () => ({
       note: 255,
       title: 255,
@@ -37,422 +37,521 @@ function D(i) {
     }),
     []
   );
-  return /* @__PURE__ */ e.createElement(
-    y.Provider,
+  return /* @__PURE__ */ t.createElement(
+    I.Provider,
     {
       value: {
-        apiSaveEndpoint: B,
-        iiifBaseUrl: $,
-        limits: Q,
-        tourTitle: d,
-        setTourTitle: g,
-        tourDescription: u,
-        setTourDescription: c,
+        apiSaveEndpoint: L,
+        iiifBaseUrl: B,
+        limits: Y,
+        tourTitle: u,
+        setTourTitle: d,
+        tourDescription: p,
+        setTourDescription: m,
         tourItems: b,
-        tourItemsDispatch: T,
+        tourItemsDispatch: S,
         navPages: f,
-        setNavPages: m,
-        activeNavPage: p,
+        setNavPages: o,
+        activeNavPage: g,
         setActiveNavPage: v,
-        navSearchButtonRef: V,
-        validityIssues: O,
-        setValidityIssues: k,
-        isSaving: M,
-        setIsSaving: L
+        navSearchButtonRef: _,
+        validityIssues: R,
+        setValidityIssues: $,
+        isSaving: Q,
+        setIsSaving: U
       }
     },
-    r
+    e
   );
 }
-D.propTypes = {
-  apiSaveEndpoint: t.string,
-  children: t.node.isRequired,
-  tourTitle: t.string,
-  tourDescription: t.string,
-  tourItems: t.instanceOf(Array),
-  navPages: t.instanceOf(Array)
+F.propTypes = {
+  apiSaveEndpoint: r.string,
+  children: r.node.isRequired,
+  tourTitle: r.string,
+  tourDescription: r.string,
+  tourItems: r.instanceOf(Array),
+  navPages: r.instanceOf(Array)
 };
-y.Provider.propTypes = {
-  value: t.shape({
-    apiSaveEndpoint: t.string,
-    iiifBaseUrl: t.string,
-    limits: t.shape({
-      note: t.number,
-      title: t.number,
-      description: t.number,
-      items: t.shape({
-        min: t.number,
-        max: t.number
+I.Provider.propTypes = {
+  value: r.shape({
+    apiSaveEndpoint: r.string,
+    iiifBaseUrl: r.string,
+    limits: r.shape({
+      note: r.number,
+      title: r.number,
+      description: r.number,
+      items: r.shape({
+        min: r.number,
+        max: r.number
       })
     }),
-    tourItems: t.instanceOf(Array),
-    tourItemsDispatch: t.func,
-    tourTitle: t.string,
-    setTourTitle: t.func,
-    tourDescription: t.string,
-    setTourDescription: t.func,
-    navPages: t.instanceOf(Array),
-    setNavPages: t.func,
-    activeNavPage: t.number,
-    setActiveNavPage: t.func,
-    navSearchButtonRef: t.shape({
-      current: t.instanceOf(Element)
+    tourItems: r.instanceOf(Array),
+    tourItemsDispatch: r.func,
+    tourTitle: r.string,
+    setTourTitle: r.func,
+    tourDescription: r.string,
+    setTourDescription: r.func,
+    navPages: r.instanceOf(Array),
+    setNavPages: r.func,
+    activeNavPage: r.number,
+    setActiveNavPage: r.func,
+    navSearchButtonRef: r.shape({
+      current: r.instanceOf(Element)
     }),
-    validityIssues: t.arrayOf(t.string),
-    setValidityIssues: t.func,
-    isSaving: t.bool,
-    setIsSaving: t.func
+    validityIssues: r.arrayOf(r.string),
+    setValidityIssues: r.func,
+    isSaving: r.bool,
+    setIsSaving: r.func
   })
 };
-function Y() {
+function J() {
   const {
-    navPages: i,
-    activeNavPage: r,
+    navPages: n,
+    activeNavPage: e,
     setActiveNavPage: a,
-    navSearchButtonRef: o,
-    isSaving: n
-  } = E(y);
-  return /* @__PURE__ */ e.createElement("nav", { id: "aic-ct-navigation", "aria-label": "Custom tour navigation" }, i.map((s, l) => /* @__PURE__ */ e.createElement(
+    navSearchButtonRef: l,
+    isSaving: i
+  } = E(I);
+  return /* @__PURE__ */ t.createElement("nav", { id: "aic-ct-navigation", "aria-label": "Custom tour navigation" }, n.map((s, c) => /* @__PURE__ */ t.createElement(
     "button",
     {
-      ref: s.id === 0 ? o : null,
+      ref: s.id === 0 ? l : null,
       key: s.id,
       id: `aic-ct-nav-button-${s.id}`,
       "aria-controls": `aic-ct-nav-page-${s.id}`,
-      "aria-pressed": s.id === r,
+      "aria-pressed": s.id === e,
       type: "button",
-      onClick: () => a(l),
-      disabled: n
+      onClick: () => a(c),
+      disabled: i
     },
     s.title
   )));
 }
-function A({ children: i }) {
-  const { setNavPages: r } = E(y);
-  return _(() => {
-    r(
-      i ? i.map((a, o) => ({
-        id: o,
+function w({ children: n }) {
+  const { setNavPages: e } = E(I);
+  return y(() => {
+    e(
+      n ? n.map((a, l) => ({
+        id: l,
         title: a.props.title
       })) : []
     );
-  }, [i, r]), /* @__PURE__ */ e.createElement("div", { id: "aic-ct-nav-pages" }, i);
+  }, [n, e]), /* @__PURE__ */ t.createElement("div", { id: "aic-ct-nav-pages" }, n);
 }
-A.propTypes = {
-  children: t.node.isRequired
+w.propTypes = {
+  children: r.node.isRequired
 };
-function S(i) {
-  const { id: r, children: a } = i, { activeNavPage: o } = E(y);
-  return /* @__PURE__ */ e.createElement(
+function P(n) {
+  const { id: e, children: a } = n, { activeNavPage: l } = E(I);
+  return /* @__PURE__ */ t.createElement(
     "div",
     {
       tabIndex: "0",
-      id: `aic-ct-nav-page-${r}`,
-      "aria-labelledby": `aic-ct-nav-button-${r}`,
-      "aria-hidden": o !== r,
-      style: o !== r ? { display: "none" } : {}
+      id: `aic-ct-nav-page-${e}`,
+      "aria-labelledby": `aic-ct-nav-button-${e}`,
+      "aria-hidden": l !== e,
+      style: l !== e ? { display: "none" } : {}
     },
     a
   );
 }
-S.propTypes = {
-  id: t.number.isRequired,
-  title: t.string.isRequired,
-  children: t.oneOfType([
-    t.arrayOf(t.element),
-    t.object
+P.propTypes = {
+  id: r.number.isRequired,
+  title: r.string.isRequired,
+  children: r.oneOfType([
+    r.arrayOf(r.element),
+    r.object
   ]).isRequired
 };
-const I = x();
-function q(i) {
+const T = x();
+function k(n) {
   const {
-    children: r,
+    children: e,
     searchResultItems: a,
-    searchQuery: o,
-    searchFetching: n,
+    searchQuery: l,
+    searchFetching: i,
     searchError: s
-  } = i, [l, d] = h(
+  } = n, [c, u] = h(
     a || null
-  ), [g, u] = h(o || ""), [c, f] = h(
-    n || !1
-  ), [m, p] = h(s || !1);
-  return /* @__PURE__ */ e.createElement(
-    I.Provider,
+  ), [d, p] = h(l || ""), [m, f] = h(
+    i || !1
+  ), [o, g] = h(s || !1), [v, b] = h(null);
+  return /* @__PURE__ */ t.createElement(
+    T.Provider,
     {
       value: {
-        searchResultItems: l,
-        setSearchResultItems: d,
-        searchQuery: g,
-        setSearchQuery: u,
-        searchFetching: c,
+        searchResultItems: c,
+        setSearchResultItems: u,
+        searchQuery: d,
+        setSearchQuery: p,
+        searchFetching: m,
         setSearchFetching: f,
-        searchError: m,
-        setSearchError: p
+        searchError: o,
+        setSearchError: g,
+        activeTheme: v,
+        setActiveTheme: b
       }
     },
-    r
+    e
   );
 }
-q.propTypes = {
-  children: t.node.isRequired,
-  searchResultItems: t.array,
-  searchQuery: t.string,
-  searchFetching: t.bool,
-  searchError: t.oneOfType([t.string, t.bool])
+k.propTypes = {
+  children: r.node.isRequired,
+  searchResultItems: r.array,
+  searchQuery: r.string,
+  searchFetching: r.bool,
+  searchError: r.oneOfType([r.string, r.bool])
 };
-I.Provider.propTypes = {
-  value: t.shape({
-    searchResultItems: t.array,
-    setSearchResultItems: t.func,
-    searchQuery: t.string,
-    setSearchQuery: t.func,
-    searchFetching: t.bool,
-    setSearchFetching: t.func,
-    searchError: t.oneOfType([t.string, t.bool]),
-    setSearchError: t.func
+T.Provider.propTypes = {
+  value: r.shape({
+    searchResultItems: r.array,
+    setSearchResultItems: r.func,
+    searchQuery: r.string,
+    setSearchQuery: r.func,
+    searchFetching: r.bool,
+    setSearchFetching: r.func,
+    searchError: r.oneOfType([r.string, r.bool]),
+    setSearchError: r.func,
+    activeTheme: r.string,
+    setActiveTheme: r.func
   }),
-  children: t.node.isRequired
+  children: r.node.isRequired
 };
-function H() {
-  const {
-    searchQuery: i,
-    setSearchQuery: r,
-    setSearchResultItems: a,
-    setSearchError: o,
-    setSearchFetching: n
-  } = E(I), [s, l] = h(i), d = (u) => {
-    const c = new URL("https://api.artic.edu/api/v1/artworks/search");
-    c.searchParams.set("query[bool][must][][term][is_on_view]", "true"), c.searchParams.set(
-      "query[bool][must][][exists][field]",
-      "description"
-    ), c.searchParams.set(
-      "query[bool][should][][exists][field]",
-      "description"
-    ), c.searchParams.set(
-      "query[bool][should][][exists][field]",
-      "subject_id"
-    ), c.searchParams.set("query[bool][should][][exists][field]", "style_id"), c.searchParams.set("query[bool][should][][term][is_boosted]", "true"), c.searchParams.set("query[bool][minimum_should_match]", "1"), c.searchParams.set(
-      "fields",
-      "artist_title,description,id,image_id,thumbnail,title"
-    ), c.searchParams.set("limit", "10"), c.searchParams.set("q", u);
-    const f = new AbortController(), m = f.signal;
-    if (u === "") {
-      a(null), n(!1), o(null);
-      return;
-    }
-    async function p() {
-      try {
-        const b = await (await fetch(c, { signal: m })).json();
-        a(b.data), n(!1);
-      } catch (v) {
-        if (v.name === "AbortError")
-          return;
-        o("Error fetching results"), n(!1);
+const q = (n) => {
+  const [e, a] = h(null), [l, i] = h(!1), [s, c] = h(null), [u, d] = h(null), { dataSubSelector: p, dataSetter: m, fetchingSetter: f, errorSetter: o } = n || {}, g = () => {
+    a(null), i(!1), c(null), d(null);
+  }, v = async (b) => {
+    i(!0);
+    const S = new AbortController();
+    d(S);
+    try {
+      const R = await (await fetch(b, { signal: S.signal })).json();
+      a(p ? R[p] : R), c(null), i(!1);
+    } catch (_) {
+      if (_.name === "AbortError") {
+        g();
+        return;
       }
+      c("Error fetching results"), i(!1);
     }
-    return n(!0), p(), () => {
-      f.abort();
-    };
-  }, g = (u) => {
-    r(s), d(s), u.preventDefault();
   };
-  return /* @__PURE__ */ e.createElement(
+  return y(() => {
+    const b = u;
+    return () => {
+      b && b.abort();
+    };
+  }, [u]), y(() => {
+    m && m(e);
+  }, [e, m]), y(() => {
+    o && o(s);
+  }, [s, o]), y(() => {
+    f && f(l);
+  }, [l, f]), { data: e, fetching: l, error: s, fetchData: v, resetState: g };
+};
+function N(n, e, a = "", l = "", i = "full", s = !0) {
+  return `${n}/${e}/${i}/${s && "!"}${a},${l}/0/default.jpg`;
+}
+function O(n) {
+  const e = new URL("https://api.artic.edu/api/v1/artworks/search");
+  return e.searchParams.set("query[bool][must][][term][is_on_view]", "true"), e.searchParams.set("query[bool][must][][exists][field]", "description"), e.searchParams.set("query[bool][should][][exists][field]", "description"), e.searchParams.set("query[bool][should][][exists][field]", "subject_id"), e.searchParams.set("query[bool][should][][exists][field]", "style_id"), e.searchParams.set("query[bool][should][][term][is_boosted]", "true"), e.searchParams.set("query[bool][minimum_should_match]", "1"), e.searchParams.set(
+    "fields",
+    "artist_title,description,id,image_id,thumbnail,title"
+  ), e.searchParams.set("limit", "10"), n.keywords && e.searchParams.set("q", n.keywords), n.subjectIds && e.searchParams.set(
+    "query[bool][must][][terms][subject_ids][]",
+    n.subjectIds
+  ), n.categoryIds && e.searchParams.set(
+    "query[bool][must][][term][category_ids][value]",
+    n.categoryIds
+  ), e;
+}
+function G() {
+  const {
+    searchQuery: n,
+    setSearchQuery: e,
+    setSearchResultItems: a,
+    setSearchFetching: l,
+    setSearchError: i,
+    setActiveTheme: s
+  } = E(T), { fetchData: c } = q({
+    dataSubSelector: "data",
+    dataSetter: a,
+    fetchingSetter: l,
+    errorSetter: i
+  }), u = (d) => {
+    c(O({ keywords: n })), s(null), d.preventDefault();
+  };
+  return /* @__PURE__ */ t.createElement(
     "form",
     {
       id: "aic-ct-search",
       role: "search",
       "aria-label": "Objects for your tour",
-      onSubmit: g
+      onSubmit: u
     },
-    /* @__PURE__ */ e.createElement("label", { htmlFor: "aic-ct-search__input", className: "sr-only" }, "Search the collection"),
-    /* @__PURE__ */ e.createElement("br", null),
-    /* @__PURE__ */ e.createElement(
+    /* @__PURE__ */ t.createElement("label", { htmlFor: "aic-ct-search__input", className: "sr-only" }, "Search the collection"),
+    /* @__PURE__ */ t.createElement("br", null),
+    /* @__PURE__ */ t.createElement(
       "input",
       {
         id: "aic-ct-search__input",
         type: "search",
         placeholder: "Search",
-        value: s,
-        onChange: (u) => {
-          u.target.value && u.target.setCustomValidity(""), l(u.target.value);
+        value: n,
+        onChange: (d) => {
+          d.target.value && d.target.setCustomValidity(""), e(d.target.value);
         },
-        onInvalid: (u) => {
-          u.target.setCustomValidity("You must enter a search term");
+        onInvalid: (d) => {
+          d.target.setCustomValidity("You must enter a search term");
         },
         required: !0
       }
     ),
-    /* @__PURE__ */ e.createElement("button", { id: "aic-ct-search__button", type: "submit" }, "Search")
+    /* @__PURE__ */ t.createElement("button", { id: "aic-ct-search__button", type: "submit" }, "Search")
   );
 }
-function F(i, r, a = "", o = "", n = "full", s = !0) {
-  return `${i}/${r}/${n}/${s && "!"}${a},${o}/0/default.jpg`;
+function V(n) {
+  const { id: e, label: a, subjectIds: l, thumbnailId: i, categoryIds: s } = n, {
+    setSearchResultItems: c,
+    setSearchFetching: u,
+    setSearchError: d,
+    setSearchQuery: p,
+    activeTheme: m,
+    setActiveTheme: f
+  } = E(T), { fetchData: o, resetState: g } = q({
+    dataSubSelector: "data",
+    dataSetter: c,
+    fetchingSetter: u,
+    errorSetter: d
+  }), v = () => {
+    m === a ? (f(null), g()) : (o(O({ subjectIds: l, categoryIds: s })), f(a), p(""));
+  };
+  return /* @__PURE__ */ t.createElement(t.Fragment, null, (m === null || m === a) && /* @__PURE__ */ t.createElement(
+    "button",
+    {
+      id: `aic-ct-theme-toggle-${e}`,
+      onClick: v,
+      "aria-pressed": m === a ? "true" : "false"
+    },
+    a
+  ));
 }
-function N(i) {
-  const { iiifBaseUrl: r, tourItems: a, tourItemsDispatch: o } = E(y), { itemData: n } = i, [s, l] = h(!1), d = () => {
-    o({
+V.propTypes = {
+  id: r.number.isRequired,
+  label: r.string.isRequired,
+  subjectIds: r.arrayOf(r.string),
+  categoryIds: r.arrayOf(r.string),
+  thumbnailId: r.string.isRequired
+};
+function K() {
+  const n = [
+    {
+      label: "Landscapes",
+      subjectIds: ["TM-8657"],
+      thumbnailId: "2d484387-2509-5e8e-2c43-22f9981972eb"
+    },
+    {
+      label: "Fashion",
+      subjectIds: ["TM-8663"],
+      thumbnailId: "b272df73-a965-ac37-4172-be4e99483637"
+    },
+    {
+      label: "Mythology",
+      subjectIds: ["TM-8766"],
+      thumbnailId: "ea8c5d62-6ce8-88e8-feb1-e0053cf534c5"
+    },
+    {
+      label: "Animals",
+      subjectIds: ["TM-12218"],
+      thumbnailId: "9ae64560-a416-ec19-851a-c76c5ca3c64f"
+    },
+    {
+      label: "Chicago artists",
+      categoryIds: ["PC-154"],
+      thumbnailId: "f7f9615d-2c2b-6b23-47b2-cd6cdc846504"
+    },
+    {
+      label: "Essentials",
+      categoryIds: ["PC-831"],
+      thumbnailId: "25c31d8d-21a4-9ea1-1d73-6a2eca4dda7e"
+    }
+  ];
+  return /* @__PURE__ */ t.createElement("div", { id: "aic-ct-themes" }, n.map((e, a) => /* @__PURE__ */ t.createElement(
+    V,
+    {
+      key: e.label,
+      id: a,
+      label: e.label,
+      subjectIds: e.subjectIds,
+      categoryIds: e.categoryIds,
+      thumbnailId: e.thumbnailId
+    }
+  )));
+}
+function j(n) {
+  const { iiifBaseUrl: e, tourItems: a, tourItemsDispatch: l } = E(I), { itemData: i } = n, [s, c] = h(!1), u = () => {
+    l({
       type: s ? "REMOVE_ITEM" : "ADD_ITEM",
-      payload: s ? n.id : n
+      payload: s ? i.id : i
     });
   };
-  return _(() => {
-    l(a.find((g) => g.id === n.id));
-  }, [a, n.id]), /* @__PURE__ */ e.createElement("li", { id: `aic-ct-search__item-${n.id}` }, n.title && /* @__PURE__ */ e.createElement("h2", null, n.title), n.image_id && /* @__PURE__ */ e.createElement(
+  return y(() => {
+    c(a.find((d) => d.id === i.id));
+  }, [a, i.id]), /* @__PURE__ */ t.createElement("li", { id: `aic-ct-search__item-${i.id}` }, i.title && /* @__PURE__ */ t.createElement("h2", null, i.title), i.image_id && /* @__PURE__ */ t.createElement(
     "img",
     {
-      src: F(r, n.image_id, "240", "240"),
-      alt: n.thumbnail.alt_text
+      src: N(e, i.image_id, "240", "240"),
+      alt: i.thumbnail.alt_text
     }
-  ), n.artist_title && /* @__PURE__ */ e.createElement("p", null, n.artist_title), n.description && /* @__PURE__ */ e.createElement("div", { dangerouslySetInnerHTML: { __html: n.description } }), (a.length < 6 || s) && /* @__PURE__ */ e.createElement(
+  ), i.artist_title && /* @__PURE__ */ t.createElement("p", null, i.artist_title), i.description && /* @__PURE__ */ t.createElement("div", { dangerouslySetInnerHTML: { __html: i.description } }), (a.length < 6 || s) && /* @__PURE__ */ t.createElement(
     "button",
     {
       type: "button",
-      onClick: d,
+      onClick: u,
       "aria-pressed": s ? "true" : "false",
       "aria-label": s ? "Remove from tour" : "Add to tour"
     },
     s ? "Remove from tour" : "Add to tour"
   ));
 }
-N.propTypes = {
-  itemData: t.shape({
-    id: t.number.isRequired,
-    title: t.string.isRequired,
-    image_id: t.string,
-    thumbnail: t.shape({
-      alt_text: t.string
+j.propTypes = {
+  itemData: r.shape({
+    id: r.number.isRequired,
+    title: r.string.isRequired,
+    image_id: r.string,
+    thumbnail: r.shape({
+      alt_text: r.string
     }),
-    artist_title: t.string,
-    description: t.string
+    artist_title: r.string,
+    description: r.string
   })
 };
-function z() {
-  const { searchError: i, searchFetching: r, searchResultItems: a } = E(I);
-  return r ? /* @__PURE__ */ e.createElement("div", { id: "aic-ct-search__loading" }, "Loading...") : i ? /* @__PURE__ */ e.createElement("div", { id: "aic-ct-search__error" }, i) : (a == null ? void 0 : a.length) === 0 ? /* @__PURE__ */ e.createElement("div", { id: "aic-ct-search__no-results" }, "Sorry, we couldn’t find any results matching your criteria") : (a == null ? void 0 : a.length) > 0 ? /* @__PURE__ */ e.createElement("ul", { id: "aic-ct-search__results" }, a.map((o) => /* @__PURE__ */ e.createElement(N, { key: o.id, itemData: o }))) : null;
+function W() {
+  const { searchError: n, searchFetching: e, searchResultItems: a } = E(T);
+  return e ? /* @__PURE__ */ t.createElement("div", { id: "aic-ct-search__loading" }, "Loading...") : n ? /* @__PURE__ */ t.createElement("div", { id: "aic-ct-search__error" }, n) : (a == null ? void 0 : a.length) === 0 ? /* @__PURE__ */ t.createElement("div", { id: "aic-ct-search__no-results" }, "Sorry, we couldn’t find any results matching your criteria") : (a == null ? void 0 : a.length) > 0 ? /* @__PURE__ */ t.createElement("ul", { id: "aic-ct-search__results" }, a.map((l) => /* @__PURE__ */ t.createElement(j, { key: l.id, itemData: l }))) : null;
 }
-function R(i, r) {
-  const [a, o] = h(i || ""), n = P(null);
+function C(n, e) {
+  const [a, l] = h(n || ""), i = A(null);
   return {
     value: a,
-    onChange: (l) => {
-      const { value: d } = l.target;
-      n.current.ariaBusy = !0, o(d), n.current.ariaBusy = !1;
+    onChange: (c) => {
+      const { value: u } = c.target;
+      i.current.ariaBusy = !0, l(u), i.current.ariaBusy = !1;
     },
-    countRef: n,
-    charsRemaining: r - a.length,
-    maxLength: r
+    countRef: i,
+    charsRemaining: e - a.length,
+    maxLength: e
   };
 }
-function w(i) {
-  var p;
-  const { itemData: r, itemIndex: a, setShouldAssignFocus: o, setRemoveButtons: n } = i, { iiifBaseUrl: s, tourItems: l, tourItemsDispatch: d, limits: g } = E(y), u = P(null), c = R((p = l[a]) == null ? void 0 : p.note, g.note), f = C(
+function M(n) {
+  var g;
+  const { itemData: e, itemIndex: a, setShouldAssignFocus: l, setRemoveButtons: i } = n, { iiifBaseUrl: s, tourItems: c, tourItemsDispatch: u, limits: d } = E(I), p = A(null), m = C((g = c[a]) == null ? void 0 : g.note, d.note), f = D(
     () => ({
-      id: r.id,
-      note: c.value
+      id: e.id,
+      note: m.value
     }),
-    [r.id, c.value]
-  ), m = () => {
-    d({
+    [e.id, m.value]
+  ), o = () => {
+    u({
       type: "REMOVE_ITEM",
-      payload: r.id
+      payload: e.id
     });
   };
-  return _(() => {
-    d({
+  return y(() => {
+    u({
       type: "UPDATE_NOTE",
       payload: f
     });
-  }, [f, d]), _(() => {
-    const v = u.current;
+  }, [f, u]), y(() => {
+    const v = p.current;
     return () => {
-      document.activeElement === v && (l.length > 1 ? l.find((b, T) => {
-        b.id === r.id && o({
+      document.activeElement === v && (c.length > 1 ? c.find((b, S) => {
+        b.id === e.id && l({
           flag: !0,
-          id: l[T !== l.length - 1 ? T + 1 : T - 1].id
+          id: c[S !== c.length - 1 ? S + 1 : S - 1].id
         });
-      }) : o({
+      }) : l({
         flag: !0,
         id: null
       }));
     };
-  }, [l, r.id, o]), _(() => (n((v) => [...v, { id: r.id, ref: u }]), () => {
-    n(
-      (v) => v.filter((b) => b.id !== r.id)
+  }, [c, e.id, l]), y(() => (i((v) => [...v, { id: e.id, ref: p }]), () => {
+    i(
+      (v) => v.filter((b) => b.id !== e.id)
     );
-  }), [n, l, r.id]), /* @__PURE__ */ e.createElement("li", { id: `aic-ct-tour__item-${r.id}` }, r.title && /* @__PURE__ */ e.createElement("h2", null, r.title), r.image_id && /* @__PURE__ */ e.createElement(
+  }), [i, c, e.id]), /* @__PURE__ */ t.createElement("li", { id: `aic-ct-tour__item-${e.id}` }, e.title && /* @__PURE__ */ t.createElement("h2", null, e.title), e.image_id && /* @__PURE__ */ t.createElement(
     "img",
     {
-      src: F(s, r.image_id, "240", "240"),
-      alt: r.thumbnail.alt_text
+      src: N(s, e.image_id, "240", "240"),
+      alt: e.thumbnail.alt_text
     }
-  ), r.artist_title && /* @__PURE__ */ e.createElement("p", null, r.artist_title), r.description && /* @__PURE__ */ e.createElement("div", { dangerouslySetInnerHTML: { __html: r.description } }), /* @__PURE__ */ e.createElement("label", { htmlFor: `aic-ct-note-${r.id}` }, "Personal note", " ", /* @__PURE__ */ e.createElement("span", { ref: c.countRef, "aria-live": "polite" }, "(", c.charsRemaining, /* @__PURE__ */ e.createElement("span", { className: "sr-only" }, " characters remaining"), ")")), /* @__PURE__ */ e.createElement("br", null), /* @__PURE__ */ e.createElement(
+  ), e.artist_title && /* @__PURE__ */ t.createElement("p", null, e.artist_title), e.description && /* @__PURE__ */ t.createElement("div", { dangerouslySetInnerHTML: { __html: e.description } }), /* @__PURE__ */ t.createElement("label", { htmlFor: `aic-ct-note-${e.id}` }, "Personal note", " ", /* @__PURE__ */ t.createElement("span", { ref: m.countRef, "aria-live": "polite" }, "(", m.charsRemaining, /* @__PURE__ */ t.createElement("span", { className: "sr-only" }, " characters remaining"), ")")), /* @__PURE__ */ t.createElement("br", null), /* @__PURE__ */ t.createElement(
     "textarea",
     {
-      id: `aic-ct-note-${r.id}`,
-      onChange: c.onChange,
+      id: `aic-ct-note-${e.id}`,
+      onChange: m.onChange,
       rows: "5",
-      value: c.value,
-      maxLength: c.maxLength
+      value: m.value,
+      maxLength: m.maxLength
     }
-  ), /* @__PURE__ */ e.createElement("br", null), /* @__PURE__ */ e.createElement(
+  ), /* @__PURE__ */ t.createElement("br", null), /* @__PURE__ */ t.createElement(
     "button",
     {
-      ref: u,
+      ref: p,
       type: "button",
       onClick: () => {
-        m(r.id);
+        o(e.id);
       }
     },
     "Remove from tour"
   ));
 }
-w.propTypes = {
-  itemData: t.shape({
-    id: t.number.isRequired,
-    title: t.string.isRequired,
-    image_id: t.string,
-    thumbnail: t.shape({
-      alt_text: t.string
+M.propTypes = {
+  itemData: r.shape({
+    id: r.number.isRequired,
+    title: r.string.isRequired,
+    image_id: r.string,
+    thumbnail: r.shape({
+      alt_text: r.string
     }),
-    artist_title: t.string,
-    description: t.string
+    artist_title: r.string,
+    description: r.string
   }),
-  itemIndex: t.number.isRequired,
-  setRemoveButtons: t.func,
-  setShouldAssignFocus: t.func
+  itemIndex: r.number.isRequired,
+  setRemoveButtons: r.func,
+  setShouldAssignFocus: r.func
 };
-function J() {
-  const { tourItems: i, navSearchButtonRef: r } = E(y), [a, o] = h({
+function X() {
+  const { tourItems: n, navSearchButtonRef: e } = E(I), [a, l] = h({
     flag: !1,
     id: null
-  }), [n, s] = h([]);
-  return _(() => {
-    a.flag && (!i.length && (r != null && r.current) ? r.current.focus() : n.find((l) => l.id === a.id).ref.current.focus(), o(!1));
-  }, [i, a, n, r]), /* @__PURE__ */ e.createElement(e.Fragment, null, i.length > 0 ? /* @__PURE__ */ e.createElement(e.Fragment, null, /* @__PURE__ */ e.createElement("h2", { id: "aic-ct-tour__heading" }, "Your tour"), /* @__PURE__ */ e.createElement("ul", { id: "aic-ct-tour__results" }, i.map((l, d) => /* @__PURE__ */ e.createElement(
-    w,
+  }), [i, s] = h([]);
+  return y(() => {
+    a.flag && (!n.length && (e != null && e.current) ? e.current.focus() : i.find((c) => c.id === a.id).ref.current.focus(), l(!1));
+  }, [n, a, i, e]), /* @__PURE__ */ t.createElement(t.Fragment, null, n.length > 0 ? /* @__PURE__ */ t.createElement(t.Fragment, null, /* @__PURE__ */ t.createElement("h2", { id: "aic-ct-tour__heading" }, "Your tour"), /* @__PURE__ */ t.createElement("ul", { id: "aic-ct-tour__results" }, n.map((c, u) => /* @__PURE__ */ t.createElement(
+    M,
     {
-      key: l.id,
+      key: c.id,
       setRemoveButtons: s,
-      itemData: l,
-      itemIndex: d,
+      itemData: c,
+      itemIndex: u,
       shouldAssignFocus: a,
-      setShouldAssignFocus: o
+      setShouldAssignFocus: l
     }
-  )))) : /* @__PURE__ */ e.createElement("div", { id: "aic-ct-tour__no-items" }, "You haven’t added any artworks to your tour yet"));
+  )))) : /* @__PURE__ */ t.createElement("div", { id: "aic-ct-tour__no-items" }, "You haven’t added any artworks to your tour yet"));
 }
-function G() {
+function Z() {
   const {
-    tourTitle: i,
-    setTourTitle: r,
+    tourTitle: n,
+    setTourTitle: e,
     tourDescription: a,
-    setTourDescription: o,
-    limits: n
-  } = E(y), s = R(i, n.title), l = R(a, n.description);
-  return _(() => {
-    r(s.value);
-  }, [s, r]), _(() => {
-    o(l.value);
-  }, [l, o]), /* @__PURE__ */ e.createElement(e.Fragment, null, /* @__PURE__ */ e.createElement("div", null, /* @__PURE__ */ e.createElement("label", { htmlFor: "aic-ct-metadata__title" }, "Tour Title", " ", /* @__PURE__ */ e.createElement("span", { ref: s.countRef, "aria-live": "polite" }, "(", s.charsRemaining, /* @__PURE__ */ e.createElement("span", { className: "sr-only" }, " characters remaining"), ")")), /* @__PURE__ */ e.createElement("br", null), /* @__PURE__ */ e.createElement(
+    setTourDescription: l,
+    limits: i
+  } = E(I), s = C(n, i.title), c = C(a, i.description);
+  return y(() => {
+    e(s.value);
+  }, [s, e]), y(() => {
+    l(c.value);
+  }, [c, l]), /* @__PURE__ */ t.createElement(t.Fragment, null, /* @__PURE__ */ t.createElement("div", null, /* @__PURE__ */ t.createElement("label", { htmlFor: "aic-ct-metadata__title" }, "Tour Title", " ", /* @__PURE__ */ t.createElement("span", { ref: s.countRef, "aria-live": "polite" }, "(", s.charsRemaining, /* @__PURE__ */ t.createElement("span", { className: "sr-only" }, " characters remaining"), ")")), /* @__PURE__ */ t.createElement("br", null), /* @__PURE__ */ t.createElement(
     "input",
     {
       type: "text",
@@ -462,40 +561,40 @@ function G() {
       maxLength: s.maxLength,
       required: !0
     }
-  )), /* @__PURE__ */ e.createElement("div", null, /* @__PURE__ */ e.createElement("label", { htmlFor: "aic-ct-metadata__description" }, "Tour Description", " ", /* @__PURE__ */ e.createElement("span", { ref: l.countRef, "aria-live": "polite" }, "(", l.charsRemaining, /* @__PURE__ */ e.createElement("span", { className: "sr-only" }, " characters remaining"), ")")), /* @__PURE__ */ e.createElement("br", null), /* @__PURE__ */ e.createElement(
+  )), /* @__PURE__ */ t.createElement("div", null, /* @__PURE__ */ t.createElement("label", { htmlFor: "aic-ct-metadata__description" }, "Tour Description", " ", /* @__PURE__ */ t.createElement("span", { ref: c.countRef, "aria-live": "polite" }, "(", c.charsRemaining, /* @__PURE__ */ t.createElement("span", { className: "sr-only" }, " characters remaining"), ")")), /* @__PURE__ */ t.createElement("br", null), /* @__PURE__ */ t.createElement(
     "textarea",
     {
       id: "aic-ct-metadata__description",
-      onChange: l.onChange,
+      onChange: c.onChange,
       rows: "5",
-      value: l.value,
-      maxLength: l.maxLength
+      value: c.value,
+      maxLength: c.maxLength
     }
   )));
 }
-function K() {
+function ee() {
   const {
-    apiSaveEndpoint: i,
-    tourTitle: r,
+    apiSaveEndpoint: n,
+    tourTitle: e,
     tourItems: a,
-    tourDescription: o,
-    validityIssues: n,
+    tourDescription: l,
+    validityIssues: i,
     setValidityIssues: s,
-    limits: l,
-    isSaving: d,
-    setIsSaving: g
-  } = E(y), [u, c] = h(null), f = async () => {
-    g(!0);
+    limits: c,
+    isSaving: u,
+    setIsSaving: d
+  } = E(I), [p, m] = h(null), f = async () => {
+    d(!0);
     try {
-      const m = await fetch(`${i}`, {
+      const o = await fetch(`${n}`, {
         method: "POST",
         headers: {
           Accept: "application/json",
           "Content-Type": "application/json"
         },
         body: JSON.stringify({
-          title: r,
-          description: o,
+          title: e,
+          description: l,
           // Pass in note as objectNote and destructure the rest as rest
           artworks: a.map(({ note: v, ...b }) => ({
             objectNote: v,
@@ -503,63 +602,63 @@ function K() {
           }))
         })
       });
-      if (!m.ok)
+      if (!o.ok)
         throw new Error(
           "There was a problem saving your tour, please try again. If the problem persists, please contact us and let us know."
         );
-      const { message: p } = await m.json();
-      c({
+      const { message: g } = await o.json();
+      m({
         type: "success",
-        message: p
+        message: g
       });
-    } catch (m) {
-      c({
+    } catch (o) {
+      m({
         type: "error",
-        message: m.message
+        message: o.message
       });
     }
-    g(!1);
+    d(!1);
   };
-  return _(() => {
-    const m = [];
-    r.length || m.push("A title is required"), r.length > l.title && m.push("Tour title must not exceed the character limit"), o.length > l.description && m.push(
+  return y(() => {
+    const o = [];
+    e.length || o.push("A title is required"), e.length > c.title && o.push("Tour title must not exceed the character limit"), l.length > c.description && o.push(
       "Tour description must not exceed the character limit"
-    ), a.length < l.items.min && m.push("At least one item is required"), a.length > l.items.max && m.push("Tours must not contain more than 6 artworks"), a.some((p) => p.note.length > l.note ? (m.push("Notes must not exceed the character limit"), !0) : !1), s(m);
-  }, [r, o, a, s, l]), /* @__PURE__ */ e.createElement(e.Fragment, null, /* @__PURE__ */ e.createElement("h2", null, "Submit your tour"), n.length ? /* @__PURE__ */ e.createElement(e.Fragment, null, /* @__PURE__ */ e.createElement("p", null, "Fix these issue before submitting your tour:"), n.length && /* @__PURE__ */ e.createElement("ul", { id: "aic-ct-validation-errors" }, n.map((m, p) => /* @__PURE__ */ e.createElement("li", { key: p }, m)))) : /* @__PURE__ */ e.createElement("div", { id: "aic-ct-validation-success" }, /* @__PURE__ */ e.createElement("div", { tabIndex: "-1", "aria-live": "polite" }, d && /* @__PURE__ */ e.createElement("p", null, "Saving..."), !d && !u && /* @__PURE__ */ e.createElement(e.Fragment, null, /* @__PURE__ */ e.createElement("p", null, "Are you sure you want to submit your tour? You won't be able to make any more changes after this stage"), /* @__PURE__ */ e.createElement(
+    ), a.length < c.items.min && o.push("At least one item is required"), a.length > c.items.max && o.push("Tours must not contain more than 6 artworks"), a.some((g) => g.note.length > c.note ? (o.push("Notes must not exceed the character limit"), !0) : !1), s(o);
+  }, [e, l, a, s, c]), /* @__PURE__ */ t.createElement(t.Fragment, null, /* @__PURE__ */ t.createElement("h2", null, "Submit your tour"), i.length ? /* @__PURE__ */ t.createElement(t.Fragment, null, /* @__PURE__ */ t.createElement("p", null, "Fix these issue before submitting your tour:"), i.length && /* @__PURE__ */ t.createElement("ul", { id: "aic-ct-validation-errors" }, i.map((o, g) => /* @__PURE__ */ t.createElement("li", { key: g }, o)))) : /* @__PURE__ */ t.createElement("div", { id: "aic-ct-validation-success" }, /* @__PURE__ */ t.createElement("div", { tabIndex: "-1", "aria-live": "polite" }, u && /* @__PURE__ */ t.createElement("p", null, "Saving..."), !u && !p && /* @__PURE__ */ t.createElement(t.Fragment, null, /* @__PURE__ */ t.createElement("p", null, "Are you sure you want to submit your tour? You won't be able to make any more changes after this stage"), /* @__PURE__ */ t.createElement(
     "button",
     {
       id: "aic-ct-save-button",
       type: "button",
       onClick: f,
-      disabled: d
+      disabled: u
     },
     "Save my tour"
-  )), u && (u.type === "success" && /* @__PURE__ */ e.createElement("div", { id: "aic-ct-save-success" }, /* @__PURE__ */ e.createElement("p", null, u.message)) || u.type === "error" && /* @__PURE__ */ e.createElement("div", { id: "aic-ct-save-error" }, /* @__PURE__ */ e.createElement("p", null, u.message), /* @__PURE__ */ e.createElement(
+  )), p && (p.type === "success" && /* @__PURE__ */ t.createElement("div", { id: "aic-ct-save-success" }, /* @__PURE__ */ t.createElement("p", null, p.message)) || p.type === "error" && /* @__PURE__ */ t.createElement("div", { id: "aic-ct-save-error" }, /* @__PURE__ */ t.createElement("p", null, p.message), /* @__PURE__ */ t.createElement(
     "button",
     {
       id: "aic-ct-save-button",
       type: "button",
       onClick: f,
-      disabled: d
+      disabled: u
     },
     "Save my tour"
   ))))));
 }
-const W = (i) => {
-  const { apiSaveEndpoint: r, tourTitle: a, tourDescription: o, tourItems: n } = i, s = {
-    apiSaveEndpoint: r,
+const te = (n) => {
+  const { apiSaveEndpoint: e, tourTitle: a, tourDescription: l, tourItems: i } = n, s = {
+    apiSaveEndpoint: e,
     tourTitle: a,
-    tourDescription: o,
-    tourItems: n
+    tourDescription: l,
+    tourItems: i
   };
-  return /* @__PURE__ */ e.createElement(D, { ...s }, /* @__PURE__ */ e.createElement(Y, null), /* @__PURE__ */ e.createElement(A, null, /* @__PURE__ */ e.createElement(S, { id: 0, title: "Search" }, /* @__PURE__ */ e.createElement(q, null, /* @__PURE__ */ e.createElement(H, null), /* @__PURE__ */ e.createElement(z, null))), /* @__PURE__ */ e.createElement(S, { id: 1, title: "Your tour" }, /* @__PURE__ */ e.createElement(G, null), /* @__PURE__ */ e.createElement(J, null)), /* @__PURE__ */ e.createElement(S, { id: 2, title: "Save your tour" }, /* @__PURE__ */ e.createElement(K, null))));
+  return /* @__PURE__ */ t.createElement(F, { ...s }, /* @__PURE__ */ t.createElement(J, null), /* @__PURE__ */ t.createElement(w, null, /* @__PURE__ */ t.createElement(P, { id: 0, title: "Search" }, /* @__PURE__ */ t.createElement(k, null, /* @__PURE__ */ t.createElement(G, null), /* @__PURE__ */ t.createElement(K, null), /* @__PURE__ */ t.createElement(W, null))), /* @__PURE__ */ t.createElement(P, { id: 1, title: "Your tour" }, /* @__PURE__ */ t.createElement(Z, null), /* @__PURE__ */ t.createElement(X, null)), /* @__PURE__ */ t.createElement(P, { id: 2, title: "Save your tour" }, /* @__PURE__ */ t.createElement(ee, null))));
 };
-W.propTypes = {
-  apiSaveEndpoint: t.string,
-  tourTitle: t.string,
-  tourDescription: t.string,
-  tourItems: t.array
+te.propTypes = {
+  apiSaveEndpoint: r.string,
+  tourTitle: r.string,
+  tourDescription: r.string,
+  tourItems: r.array
 };
 export {
-  W as default
+  te as default
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@types/react": "^16.9.0",
         "@types/react-dom": "^16.9.0",
         "@vitejs/plugin-react": "^4.0.3",
-        "cypress": "^13.3.2",
+        "cypress": "^13.4.0",
         "eslint": "^8.45.0",
         "eslint-config-prettier": "^8.8.0",
         "eslint-plugin-cypress": "^2.15.1",
@@ -1845,9 +1845,9 @@
       "dev": true
     },
     "node_modules/cypress": {
-      "version": "13.3.2",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.3.2.tgz",
-      "integrity": "sha512-ArLmZObcLC+xxCp7zJZZbhby9FUf5CueLej9dUM4+5j37FTS4iMSgHxQLDu01PydFUvDXcNoIVRCYrHHxD7Ybg==",
+      "version": "13.4.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.4.0.tgz",
+      "integrity": "sha512-KeWNC9xSHG/ewZURVbaQsBQg2mOKw4XhjJZFKjWbEjgZCdxpPXLpJnfq5Jns1Gvnjp6AlnIfpZfWFlDgVKXdWQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@types/react": "^16.9.0",
     "@types/react-dom": "^16.9.0",
     "@vitejs/plugin-react": "^4.0.3",
-    "cypress": "^13.3.2",
+    "cypress": "^13.4.0",
     "eslint": "^8.45.0",
     "eslint-config-prettier": "^8.8.0",
     "eslint-plugin-cypress": "^2.15.1",

--- a/src/CustomTourBuilder.cy.jsx
+++ b/src/CustomTourBuilder.cy.jsx
@@ -92,6 +92,8 @@ describe("<CustomTourBuilder />", () => {
     cy.get("#aic-ct-search__loading").should("have.text", "Loading...");
     cy.get("#aic-ct-search__results").should("exist");
     cy.get("#aic-ct-search__results li").should("have.length", 10);
+    cy.get("#aic-ct-theme-toggle-0").click();
+    cy.get("#aic-ct-search__results").should("not.exist");
   });
 
   it("Can add and remove up to 6 artworks to the tour", () => {

--- a/src/CustomTourBuilder.cy.jsx
+++ b/src/CustomTourBuilder.cy.jsx
@@ -39,7 +39,7 @@ describe("<CustomTourBuilder />", () => {
     );
   });
 
-  it("Can perform a search and show results", () => {
+  it("Can perform a keyword search and show results", () => {
     let imageInterceptCount = 0;
     cy.intercept(
       "GET",
@@ -62,6 +62,33 @@ describe("<CustomTourBuilder />", () => {
     cy.mount(<CustomTourBuilder />);
     cy.get("#aic-ct-search__input").type("test");
     cy.get("#aic-ct-search__button").click();
+    cy.get("#aic-ct-search__loading").should("have.text", "Loading...");
+    cy.get("#aic-ct-search__results").should("exist");
+    cy.get("#aic-ct-search__results li").should("have.length", 10);
+  });
+
+  it("Can perform a search on a theme and show results", () => {
+    let imageInterceptCount = 0;
+    cy.intercept(
+      "GET",
+      "https://artic.edu/iiif/2/*/full/!240,240/0/default.jpg",
+      (req) => {
+        imageInterceptCount += 1;
+        req.reply({
+          fixture: `../../cypress/fixtures/images/image_${imageInterceptCount}.jpg`,
+        });
+      },
+    ).as("images");
+
+    // Use intercept to ping the search api and use the search.json fixture
+    // but wait while we check the loading message
+    cy.intercept("GET", "https://api.artic.edu/api/v1/artworks/search*", {
+      fixture: "json/search.json",
+      delayMs: 80,
+    }).as("search");
+
+    cy.mount(<CustomTourBuilder />);
+    cy.get("#aic-ct-theme-toggle-0").click();
     cy.get("#aic-ct-search__loading").should("have.text", "Loading...");
     cy.get("#aic-ct-search__results").should("exist");
     cy.get("#aic-ct-search__results li").should("have.length", 10);

--- a/src/CustomTourBuilder.jsx
+++ b/src/CustomTourBuilder.jsx
@@ -3,6 +3,7 @@ import Navigation from "./components/navigation/Navigation";
 import NavPages from "./components/navigation/NavPages";
 import NavPage from "./components/navigation/NavPage";
 import SearchBar from "./components/search/SearchBar";
+import Themes from "./components/search/Themes";
 import SearchResults from "./components/search/SearchResults";
 import TourItems from "./components/tour/TourItems";
 import TourMetadata from "./components/tour/TourMetadata";
@@ -28,6 +29,7 @@ const CustomTourBuilder = (props) => {
         <NavPage id={0} title="Search">
           <SearchProvider>
             <SearchBar />
+            <Themes />
             <SearchResults />
           </SearchProvider>
         </NavPage>

--- a/src/components/search/SearchBar.cy.jsx
+++ b/src/components/search/SearchBar.cy.jsx
@@ -21,6 +21,24 @@ describe("<SearchBar />", () => {
       .should("have.attr", "required");
   });
 
+  it("Requests the correct URL when performing a keyword search", () => {
+    cy.intercept("GET", "https://api.artic.edu/api/v1/artworks/search*", {
+      fixture: "json/search.json",
+      delayMs: 80,
+    }).as("search");
+
+    cy.mount(
+      <AppProvider>
+        <SearchProvider>
+          <SearchBar />
+        </SearchProvider>
+      </AppProvider>,
+    );
+    cy.get("#aic-ct-search__input").type("test");
+    cy.get("#aic-ct-search__button").click();
+    cy.get("@search").its("request.url").should("include", "q=test");
+  });
+
   it("Validates as expected", () => {
     cy.mount(
       <AppProvider>

--- a/src/components/search/SearchBar.jsx
+++ b/src/components/search/SearchBar.jsx
@@ -7,13 +7,13 @@ import { createSearchURL } from "../../utils";
  */
 function SearchBar() {
   const {
-    searchQuery,
+    inputValue,
+    setInputValue,
     setSearchQuery,
     setSearchResultItems,
     setSearchError,
     setSearchFetching,
   } = useContext(SearchContext);
-  const [inputValue, setInputValue] = useState(searchQuery);
 
   const fetchItems = (keywords) => {
     // Generate request URL

--- a/src/components/search/SearchBar.jsx
+++ b/src/components/search/SearchBar.jsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect } from "react";
+import React, { useContext } from "react";
 import { SearchContext } from "../../contexts/SearchContext";
 import useFetch from "../../hooks/useFetch";
 import { createSearchUrl } from "../../utils";
@@ -14,26 +14,18 @@ function SearchBar() {
     setSearchFetching,
     setSearchError,
   } = useContext(SearchContext);
-  const { data, fetching, error, fetchData } = useFetch();
+
+  const { fetchData } = useFetch({
+    dataSubSelector: "data",
+    dataSetter: setSearchResultItems,
+    fetchingSetter: setSearchFetching,
+    errorSetter: setSearchError,
+  });
 
   const handleSubmit = (event) => {
     fetchData(createSearchUrl({ keywords: searchQuery }));
     event.preventDefault();
   };
-
-  useEffect(() => {
-    // "data" is contingent on handleSubmit being called
-    if (!data) return;
-    setSearchResultItems(data.data);
-  }, [data, setSearchResultItems]);
-
-  useEffect(() => {
-    setSearchError(error);
-  }, [error, setSearchError]);
-
-  useEffect(() => {
-    setSearchFetching(fetching);
-  }, [fetching, setSearchFetching]);
 
   return (
     <form

--- a/src/components/search/SearchBar.jsx
+++ b/src/components/search/SearchBar.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useContext } from "react";
 import { SearchContext } from "../../contexts/SearchContext";
+import { createSearchURL } from "../../utils";
 
 /**
  * SearchBar
@@ -15,32 +16,8 @@ function SearchBar() {
   const [inputValue, setInputValue] = useState(searchQuery);
 
   const fetchItems = (keywords) => {
-    // Build the API request URL
-    // I've broken this up to make it easer to reason about and manipulate
-    const apiUrl = new URL("https://api.artic.edu/api/v1/artworks/search");
-    apiUrl.searchParams.set("query[bool][must][][term][is_on_view]", "true");
-    apiUrl.searchParams.set(
-      "query[bool][must][][exists][field]",
-      "description",
-    );
-    apiUrl.searchParams.set(
-      "query[bool][should][][exists][field]",
-      "description",
-    );
-    apiUrl.searchParams.set(
-      "query[bool][should][][exists][field]",
-      "subject_id",
-    );
-    apiUrl.searchParams.set("query[bool][should][][exists][field]", "style_id");
-    apiUrl.searchParams.set("query[bool][should][][term][is_boosted]", "true");
-    apiUrl.searchParams.set("query[bool][minimum_should_match]", "1");
-    // "true" will return all fields for debugging
-    apiUrl.searchParams.set(
-      "fields",
-      "artist_title,description,id,image_id,thumbnail,title",
-    );
-    apiUrl.searchParams.set("limit", "10");
-    apiUrl.searchParams.set("q", keywords);
+    // Generate request URL
+    const apiUrl = createSearchURL({ keywords });
 
     // Provide an AbortController to cancel the fetch request if the keywords change
     const abortController = new AbortController();
@@ -69,6 +46,7 @@ function SearchBar() {
         setSearchFetching(false);
       }
     }
+
     setSearchFetching(true);
     getData();
 

--- a/src/components/search/SearchBar.jsx
+++ b/src/components/search/SearchBar.jsx
@@ -13,6 +13,7 @@ function SearchBar() {
     setSearchResultItems,
     setSearchFetching,
     setSearchError,
+    setActiveTheme,
   } = useContext(SearchContext);
 
   const { fetchData } = useFetch({
@@ -24,6 +25,8 @@ function SearchBar() {
 
   const handleSubmit = (event) => {
     fetchData(createSearchUrl({ keywords: searchQuery }));
+    // Deselect any active theme
+    setActiveTheme(null);
     event.preventDefault();
   };
 

--- a/src/components/search/ThemeToggle.jsx
+++ b/src/components/search/ThemeToggle.jsx
@@ -1,4 +1,5 @@
-import React from "react";
+import React, { useContext } from "react";
+import { SearchContext } from "../../contexts/SearchContext";
 import { createSearchUrl } from "../../utils";
 import useFetch from "../../hooks/useFetch";
 import PropTypes from "prop-types";
@@ -7,18 +8,35 @@ import PropTypes from "prop-types";
  * ThemeToggle
  */
 function ThemeToggle(props) {
-  const { label, subjectIds, thumbnailId, categoryIds } = props;
-  const { data, fetching, error, fetchData } = useFetch();
+  const { id, label, subjectIds, thumbnailId, categoryIds } = props;
+  const {
+    setSearchResultItems,
+    setSearchFetching,
+    setSearchError,
+    setSearchQuery,
+  } = useContext(SearchContext);
+  const { fetchData } = useFetch({
+    dataSubSelector: "data",
+    dataSetter: setSearchResultItems,
+    fetchingSetter: setSearchFetching,
+    errorSetter: setSearchError,
+  });
 
   const handleClick = () => {
-    // fetchData(createSearchUrl({ subjectIds, categoryIds }));
-    console.log(createSearchUrl({ subjectIds, categoryIds }).toString());
+    fetchData(createSearchUrl({ subjectIds, categoryIds }));
+    // Empty the search field
+    setSearchQuery("");
   };
 
-  return <button onClick={handleClick}>{label}</button>;
+  return (
+    <button id={`aic-ct-theme-toggle-${id}`} onClick={handleClick}>
+      {label}
+    </button>
+  );
 }
 
 ThemeToggle.propTypes = {
+  id: PropTypes.number.isRequired,
   label: PropTypes.string.isRequired,
   subjectIds: PropTypes.arrayOf(PropTypes.string),
   categoryIds: PropTypes.arrayOf(PropTypes.string),

--- a/src/components/search/ThemeToggle.jsx
+++ b/src/components/search/ThemeToggle.jsx
@@ -8,7 +8,7 @@ import PropTypes from "prop-types";
  * ThemeToggle
  */
 function ThemeToggle(props) {
-  const { id, label, subjectIds, thumbnailId, categoryIds } = props;
+  const { id, label, subjectIds, categoryIds } = props;
   const {
     setSearchResultItems,
     setSearchFetching,

--- a/src/components/search/ThemeToggle.jsx
+++ b/src/components/search/ThemeToggle.jsx
@@ -14,6 +14,8 @@ function ThemeToggle(props) {
     setSearchFetching,
     setSearchError,
     setSearchQuery,
+    activeTheme,
+    setActiveTheme,
   } = useContext(SearchContext);
   const { fetchData } = useFetch({
     dataSubSelector: "data",
@@ -23,15 +25,30 @@ function ThemeToggle(props) {
   });
 
   const handleClick = () => {
-    fetchData(createSearchUrl({ subjectIds, categoryIds }));
-    // Empty the search field
-    setSearchQuery("");
+    if (activeTheme === label) {
+      // Deselect the theme
+      setActiveTheme(null);
+    } else {
+      fetchData(createSearchUrl({ subjectIds, categoryIds }));
+      // Clicking while active removes the theme
+      setActiveTheme(label);
+      // Empty the search field
+      setSearchQuery("");
+    }
   };
 
   return (
-    <button id={`aic-ct-theme-toggle-${id}`} onClick={handleClick}>
-      {label}
-    </button>
+    <>
+      {(activeTheme === null || activeTheme === label) && (
+        <button
+          id={`aic-ct-theme-toggle-${id}`}
+          onClick={handleClick}
+          aria-pressed={activeTheme === label ? "true" : "false"}
+        >
+          {label}
+        </button>
+      )}
+    </>
   );
 }
 

--- a/src/components/search/ThemeToggle.jsx
+++ b/src/components/search/ThemeToggle.jsx
@@ -1,18 +1,27 @@
 import React from "react";
+import { createSearchUrl } from "../../utils";
+import useFetch from "../../hooks/useFetch";
 import PropTypes from "prop-types";
 
 /**
  * ThemeToggle
  */
 function ThemeToggle(props) {
-  const { label, subjectId, thumbnailId, categoryId } = props;
-  return <button>{label}</button>;
+  const { label, subjectIds, thumbnailId, categoryIds } = props;
+  const { data, fetching, error, fetchData } = useFetch();
+
+  const handleClick = () => {
+    // fetchData(createSearchUrl({ subjectIds, categoryIds }));
+    console.log(createSearchUrl({ subjectIds, categoryIds }).toString());
+  };
+
+  return <button onClick={handleClick}>{label}</button>;
 }
 
 ThemeToggle.propTypes = {
   label: PropTypes.string.isRequired,
-  subjectId: PropTypes.string,
-  categoryId: PropTypes.string,
+  subjectIds: PropTypes.arrayOf(PropTypes.string),
+  categoryIds: PropTypes.arrayOf(PropTypes.string),
   thumbnailId: PropTypes.string.isRequired,
 };
 

--- a/src/components/search/ThemeToggle.jsx
+++ b/src/components/search/ThemeToggle.jsx
@@ -17,7 +17,7 @@ function ThemeToggle(props) {
     activeTheme,
     setActiveTheme,
   } = useContext(SearchContext);
-  const { fetchData } = useFetch({
+  const { fetchData, resetState } = useFetch({
     dataSubSelector: "data",
     dataSetter: setSearchResultItems,
     fetchingSetter: setSearchFetching,
@@ -28,6 +28,8 @@ function ThemeToggle(props) {
     if (activeTheme === label) {
       // Deselect the theme
       setActiveTheme(null);
+      // Should remove results
+      resetState();
     } else {
       fetchData(createSearchUrl({ subjectIds, categoryIds }));
       // Clicking while active removes the theme

--- a/src/components/search/ThemeToggle.jsx
+++ b/src/components/search/ThemeToggle.jsx
@@ -1,0 +1,18 @@
+import React from "react";
+import PropTypes from "prop-types";
+
+/**
+ * ThemeToggle
+ */
+function ThemeToggle(props) {
+  const { label, subjectId, thumbnailId } = props;
+  return <button>{label}</button>;
+}
+
+ThemeToggle.propTypes = {
+  label: PropTypes.string.isRequired,
+  subjectId: PropTypes.string.isRequired,
+  thumbnailId: PropTypes.string.isRequired,
+};
+
+export default ThemeToggle;

--- a/src/components/search/ThemeToggle.jsx
+++ b/src/components/search/ThemeToggle.jsx
@@ -5,13 +5,14 @@ import PropTypes from "prop-types";
  * ThemeToggle
  */
 function ThemeToggle(props) {
-  const { label, subjectId, thumbnailId } = props;
+  const { label, subjectId, thumbnailId, categoryId } = props;
   return <button>{label}</button>;
 }
 
 ThemeToggle.propTypes = {
   label: PropTypes.string.isRequired,
-  subjectId: PropTypes.string.isRequired,
+  subjectId: PropTypes.string,
+  categoryId: PropTypes.string,
   thumbnailId: PropTypes.string.isRequired,
 };
 

--- a/src/components/search/Themes.cy.jsx
+++ b/src/components/search/Themes.cy.jsx
@@ -1,0 +1,18 @@
+import React from "react";
+import Themes from "./Themes";
+import { AppProvider } from "../../contexts/AppContext";
+import { SearchProvider } from "../../contexts/SearchContext";
+
+describe("<Themes />", () => {
+  it("Renders", () => {
+    cy.mount(
+      <AppProvider>
+        <SearchProvider>
+          <Themes />
+        </SearchProvider>
+      </AppProvider>,
+    );
+    cy.get("#aic-ct-themes").should("exist");
+    cy.get("#aic-ct-themes button").should("have.length", 6);
+  });
+});

--- a/src/components/search/Themes.jsx
+++ b/src/components/search/Themes.jsx
@@ -5,6 +5,8 @@ import ThemeToggle from "./ThemeToggle";
  * Themes
  */
 function Themes() {
+  // TODO: There's interest in having this in some way configurable
+  // Best way to achieve this is TBD
   const themes = [
     {
       label: "Landscapes",
@@ -40,9 +42,10 @@ function Themes() {
 
   return (
     <div>
-      {themes.map((theme) => (
+      {themes.map((theme, index) => (
         <ThemeToggle
           key={theme.label}
+          id={index}
           label={theme.label}
           subjectIds={theme.subjectIds}
           categoryIds={theme.categoryIds}

--- a/src/components/search/Themes.jsx
+++ b/src/components/search/Themes.jsx
@@ -1,0 +1,55 @@
+import React from "react";
+import ThemeToggle from "./ThemeToggle";
+
+/**
+ * Themes
+ */
+function Themes() {
+  const themes = [
+    {
+      label: "Landscapes",
+      subjectId: "TM-8657",
+      thumbnailId: "2d484387-2509-5e8e-2c43-22f9981972eb",
+    },
+    {
+      label: "Fashion",
+      subjectId: "TM-8663",
+      thumbnailId: "b272df73-a965-ac37-4172-be4e99483637",
+    },
+    {
+      label: "Mythology",
+      subjectId: "TM-8766",
+      thumbnailId: "ea8c5d62-6ce8-88e8-feb1-e0053cf534c5",
+    },
+    {
+      label: "Animals",
+      subjectId: "TM-12218",
+      thumbnailId: "9ae64560-a416-ec19-851a-c76c5ca3c64f",
+    },
+    {
+      label: "Chicago artists",
+      subjectId: "TM-8663",
+      thumbnailId: "f7f9615d-2c2b-6b23-47b2-cd6cdc846504",
+    },
+    {
+      label: "Essentials",
+      subjectId: "TM-8663",
+      thumbnailId: "25c31d8d-21a4-9ea1-1d73-6a2eca4dda7e",
+    },
+  ];
+
+  return (
+    <div>
+      {themes.map((theme) => (
+        <ThemeToggle
+          key={theme.subject_id}
+          label={theme.label}
+          subjectId={theme.subjectId}
+          thumbnailId={theme.thumbnailId}
+        />
+      ))}
+    </div>
+  );
+}
+
+export default Themes;

--- a/src/components/search/Themes.jsx
+++ b/src/components/search/Themes.jsx
@@ -41,7 +41,7 @@ function Themes() {
   ];
 
   return (
-    <div>
+    <div id="aic-ct-themes">
       {themes.map((theme, index) => (
         <ThemeToggle
           key={theme.label}

--- a/src/components/search/Themes.jsx
+++ b/src/components/search/Themes.jsx
@@ -28,12 +28,12 @@ function Themes() {
     },
     {
       label: "Chicago artists",
-      subjectId: "TM-8663",
+      categoryId: "PC-154",
       thumbnailId: "f7f9615d-2c2b-6b23-47b2-cd6cdc846504",
     },
     {
       label: "Essentials",
-      subjectId: "TM-8663",
+      categoryId: "PC-831",
       thumbnailId: "25c31d8d-21a4-9ea1-1d73-6a2eca4dda7e",
     },
   ];
@@ -42,7 +42,7 @@ function Themes() {
     <div>
       {themes.map((theme) => (
         <ThemeToggle
-          key={theme.subject_id}
+          key={theme.label}
           label={theme.label}
           subjectId={theme.subjectId}
           thumbnailId={theme.thumbnailId}

--- a/src/components/search/Themes.jsx
+++ b/src/components/search/Themes.jsx
@@ -8,32 +8,32 @@ function Themes() {
   const themes = [
     {
       label: "Landscapes",
-      subjectId: "TM-8657",
+      subjectIds: ["TM-8657"],
       thumbnailId: "2d484387-2509-5e8e-2c43-22f9981972eb",
     },
     {
       label: "Fashion",
-      subjectId: "TM-8663",
+      subjectIds: ["TM-8663"],
       thumbnailId: "b272df73-a965-ac37-4172-be4e99483637",
     },
     {
       label: "Mythology",
-      subjectId: "TM-8766",
+      subjectIds: ["TM-8766"],
       thumbnailId: "ea8c5d62-6ce8-88e8-feb1-e0053cf534c5",
     },
     {
       label: "Animals",
-      subjectId: "TM-12218",
+      subjectIds: ["TM-12218"],
       thumbnailId: "9ae64560-a416-ec19-851a-c76c5ca3c64f",
     },
     {
       label: "Chicago artists",
-      categoryId: "PC-154",
+      categoryIds: ["PC-154"],
       thumbnailId: "f7f9615d-2c2b-6b23-47b2-cd6cdc846504",
     },
     {
       label: "Essentials",
-      categoryId: "PC-831",
+      categoryIds: ["PC-831"],
       thumbnailId: "25c31d8d-21a4-9ea1-1d73-6a2eca4dda7e",
     },
   ];
@@ -44,7 +44,8 @@ function Themes() {
         <ThemeToggle
           key={theme.label}
           label={theme.label}
-          subjectId={theme.subjectId}
+          subjectIds={theme.subjectIds}
+          categoryIds={theme.categoryIds}
           thumbnailId={theme.thumbnailId}
         />
       ))}

--- a/src/components/search/ThemesToggle.cy.jsx
+++ b/src/components/search/ThemesToggle.cy.jsx
@@ -1,18 +1,17 @@
 import React from "react";
-import Themes from "./Themes";
+import ThemeToggle from "./ThemeToggle";
 import { AppProvider } from "../../contexts/AppContext";
 import { SearchProvider } from "../../contexts/SearchContext";
 
-describe("<ThemeToggle />", () => {
+describe("<Themes />", () => {
   it("Renders", () => {
     cy.mount(
       <AppProvider>
         <SearchProvider>
-          <Themes />
+          <ThemeToggle id="0" label="Test theme" categoryIds={["TM-8657"]} />
         </SearchProvider>
       </AppProvider>,
     );
-    cy.get("#aic-ct-themes").should("exist");
-    cy.get("#aic-ct-themes button").should("have.length", 6);
+    cy.get("#aic-ct-theme-toggle-0").should("exist");
   });
 });

--- a/src/components/search/ThemesToggle.cy.jsx
+++ b/src/components/search/ThemesToggle.cy.jsx
@@ -8,10 +8,54 @@ describe("<Themes />", () => {
     cy.mount(
       <AppProvider>
         <SearchProvider>
-          <ThemeToggle id="0" label="Test theme" categoryIds={["TM-8657"]} />
+          <ThemeToggle id="0" label="Test theme" subjectIds={["TM-8657"]} />
         </SearchProvider>
       </AppProvider>,
     );
     cy.get("#aic-ct-theme-toggle-0").should("exist");
+  });
+
+  it("Requests the correct URL with subjectIds", () => {
+    cy.intercept("GET", "https://api.artic.edu/api/v1/artworks/search*", {
+      fixture: "json/search.json",
+      delayMs: 80,
+    }).as("search");
+
+    cy.mount(
+      <AppProvider>
+        <SearchProvider>
+          <ThemeToggle id="0" label="Test theme" subjectIds={["TM-8657"]} />
+        </SearchProvider>
+      </AppProvider>,
+    );
+    cy.get("#aic-ct-theme-toggle-0").click();
+    cy.get("@search")
+      .its("request.url")
+      .should(
+        "include",
+        "query%5Bbool%5D%5Bmust%5D%5B%5D%5Bterms%5D%5Bsubject_ids%5D%5B%5D=TM-8657",
+      );
+  });
+
+  it("Requests the correct URL with categoryIds", () => {
+    cy.intercept("GET", "https://api.artic.edu/api/v1/artworks/search*", {
+      fixture: "json/search.json",
+      delayMs: 80,
+    }).as("search");
+
+    cy.mount(
+      <AppProvider>
+        <SearchProvider>
+          <ThemeToggle id="0" label="Test theme" categoryIds={["PC-154"]} />
+        </SearchProvider>
+      </AppProvider>,
+    );
+    cy.get("#aic-ct-theme-toggle-0").click();
+    cy.get("@search")
+      .its("request.url")
+      .should(
+        "include",
+        "query%5Bbool%5D%5Bmust%5D%5B%5D%5Bterm%5D%5Bcategory_ids%5D%5Bvalue%5D=PC-154",
+      );
   });
 });

--- a/src/contexts/SearchContext.jsx
+++ b/src/contexts/SearchContext.jsx
@@ -22,6 +22,7 @@ export function SearchProvider(props) {
     searchFetchingValue || false,
   );
   const [searchError, setSearchError] = useState(searchErrorValue || false);
+  const [activeTheme, setActiveTheme] = useState(null);
 
   return (
     <SearchContext.Provider
@@ -34,6 +35,8 @@ export function SearchProvider(props) {
         setSearchFetching,
         searchError,
         setSearchError,
+        activeTheme,
+        setActiveTheme,
       }}
     >
       {children}
@@ -59,6 +62,8 @@ SearchContext.Provider.propTypes = {
     setSearchFetching: PropTypes.func,
     searchError: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
     setSearchError: PropTypes.func,
+    activeTheme: PropTypes.string,
+    setActiveTheme: PropTypes.func,
   }),
   children: PropTypes.node.isRequired,
 };

--- a/src/contexts/SearchContext.jsx
+++ b/src/contexts/SearchContext.jsx
@@ -18,7 +18,6 @@ export function SearchProvider(props) {
     searchResultItemsValue || null,
   );
   const [searchQuery, setSearchQuery] = useState(searchQueryValue || "");
-  const [inputValue, setInputValue] = useState(searchQueryValue || "");
   const [searchFetching, setSearchFetching] = useState(
     searchFetchingValue || false,
   );
@@ -27,8 +26,6 @@ export function SearchProvider(props) {
   return (
     <SearchContext.Provider
       value={{
-        inputValue,
-        setInputValue,
         searchResultItems,
         setSearchResultItems,
         searchQuery,
@@ -54,8 +51,6 @@ SearchProvider.propTypes = {
 
 SearchContext.Provider.propTypes = {
   value: PropTypes.shape({
-    inputValue: PropTypes.string,
-    setInputValue: PropTypes.func,
     searchResultItems: PropTypes.array,
     setSearchResultItems: PropTypes.func,
     searchQuery: PropTypes.string,

--- a/src/contexts/SearchContext.jsx
+++ b/src/contexts/SearchContext.jsx
@@ -18,6 +18,7 @@ export function SearchProvider(props) {
     searchResultItemsValue || null,
   );
   const [searchQuery, setSearchQuery] = useState(searchQueryValue || "");
+  const [inputValue, setInputValue] = useState(searchQueryValue || "");
   const [searchFetching, setSearchFetching] = useState(
     searchFetchingValue || false,
   );
@@ -26,6 +27,8 @@ export function SearchProvider(props) {
   return (
     <SearchContext.Provider
       value={{
+        inputValue,
+        setInputValue,
         searchResultItems,
         setSearchResultItems,
         searchQuery,
@@ -51,6 +54,8 @@ SearchProvider.propTypes = {
 
 SearchContext.Provider.propTypes = {
   value: PropTypes.shape({
+    inputValue: PropTypes.string,
+    setInputValue: PropTypes.func,
     searchResultItems: PropTypes.array,
     setSearchResultItems: PropTypes.func,
     searchQuery: PropTypes.string,

--- a/src/hooks/useFetch.jsx
+++ b/src/hooks/useFetch.jsx
@@ -40,6 +40,7 @@ const useFetch = () => {
       const res = await fetch(url, { signal: newAbortController.signal });
       const data = await res.json();
       setData(data);
+      setError(null);
       setFetching(false);
     } catch (error) {
       // Explicity ignore AbortError's as they aren't really errors as far as we're concerned

--- a/src/hooks/useFetch.jsx
+++ b/src/hooks/useFetch.jsx
@@ -1,15 +1,26 @@
 import { useEffect, useState } from "react";
 
 /**
+ * @typedef {object} useFetchOptions
+ * @property {string} dataSubSelector - The key to use when setting the data state
+ * @property {function} dataSetter - Function to call when setting the data state
+ * @property {function} fetchingSetter - Function to call when setting the fetching state
+ * @property {function} errorSetter - Function to call when setting the error state
+ */
+
+/**
  * useFetch
  * Custom hook for fetching data from the API
+ * @param {useFetchOptions} options
  * @returns {object} { data, fetching, error, fetchData, resetState }
  */
-const useFetch = () => {
+const useFetch = (options) => {
   const [data, setData] = useState(null);
   const [fetching, setFetching] = useState(false);
   const [error, setError] = useState(null);
   const [abortController, setAbortController] = useState(null);
+  const { dataSubSelector, dataSetter, fetchingSetter, errorSetter } =
+    options || {};
 
   // Reset the state to the initial values
   const resetState = () => {
@@ -39,7 +50,7 @@ const useFetch = () => {
     try {
       const res = await fetch(url, { signal: newAbortController.signal });
       const data = await res.json();
-      setData(data);
+      setData(dataSubSelector ? data[dataSubSelector] : data);
       setError(null);
       setFetching(false);
     } catch (error) {
@@ -66,6 +77,21 @@ const useFetch = () => {
       }
     };
   }, [abortController]);
+
+  useEffect(() => {
+    if (!dataSetter) return;
+    dataSetter(data);
+  }, [data, dataSetter]);
+
+  useEffect(() => {
+    if (!errorSetter) return;
+    errorSetter(error);
+  }, [error, errorSetter]);
+
+  useEffect(() => {
+    if (!fetchingSetter) return;
+    fetchingSetter(fetching);
+  }, [fetching, fetchingSetter]);
 
   return { data, fetching, error, fetchData, resetState };
 };

--- a/src/hooks/useFetch.jsx
+++ b/src/hooks/useFetch.jsx
@@ -1,0 +1,72 @@
+import { useEffect, useState } from "react";
+
+/**
+ * useFetch
+ * Custom hook for fetching data from the API
+ * @returns {object} { data, fetching, error, fetchData, resetState }
+ */
+const useFetch = () => {
+  const [data, setData] = useState(null);
+  const [fetching, setFetching] = useState(false);
+  const [error, setError] = useState(null);
+  const [abortController, setAbortController] = useState(null);
+
+  // Reset the state to the initial values
+  const resetState = () => {
+    setData(null);
+    setFetching(false);
+    setError(null);
+    setAbortController(null);
+  };
+
+  /**
+   * fetchData
+   * Fetch data and update state
+   * @param {string|URL} url
+   * @returns
+   */
+  const fetchData = async (url) => {
+    setFetching(true);
+    // Provide an AbortController to cancel the fetch request
+    // if this function runs again before the request completes
+
+    // Note that storing this in a variable bypasses race conditions
+    // Where the state might not be updated by the time we need to use it
+    // Using a ref would also work, but this is nicer
+    const newAbortController = new AbortController();
+    setAbortController(newAbortController);
+
+    try {
+      const res = await fetch(url, { signal: newAbortController.signal });
+      const data = await res.json();
+      setData(data);
+      setFetching(false);
+    } catch (error) {
+      // Explicity ignore AbortError's as they aren't really errors as far as we're concerned
+      if (error.name === "AbortError") {
+        resetState();
+        return;
+      }
+
+      setError("Error fetching results");
+      setFetching(false);
+    }
+  };
+
+  useEffect(() => {
+    // setController is called when a new fetch request is made
+    // Triggering this effect which will abort the previous request
+    // Remember: the callback runs before the next render
+    const prevAbortController = abortController;
+
+    return () => {
+      if (prevAbortController) {
+        prevAbortController.abort();
+      }
+    };
+  }, [abortController]);
+
+  return { data, fetching, error, fetchData, resetState };
+};
+
+export default useFetch;

--- a/src/utils.js
+++ b/src/utils.js
@@ -52,9 +52,15 @@ export function createSearchURL(queryParams) {
   if (queryParams.keywords) {
     url.searchParams.set("q", queryParams.keywords);
   }
-  if (queryParams.themes) {
+  if (queryParams.subjectIds) {
     url.searchParams.set(
       "query[bool][must][][terms][subject_ids][]",
+      queryParams.themes,
+    );
+  }
+  if (queryParams.categoryIds) {
+    url.searchParams.set(
+      "query[bool][must][][term][category_ids][value]",
       queryParams.themes,
     );
   }

--- a/src/utils.js
+++ b/src/utils.js
@@ -24,7 +24,8 @@ export function iiifUrl(
 /**
  * @typedef {Object} QueryParams
  * @property {string} keywords - Search keywords
- * @property {string[]} - Themes
+ * @property {string[]} subjectIds - Array of subject ids
+ * @property {string[]} categoryIds - Array of category ids
  */
 
 /**
@@ -55,13 +56,13 @@ export function createSearchUrl(queryParams) {
   if (queryParams.subjectIds) {
     url.searchParams.set(
       "query[bool][must][][terms][subject_ids][]",
-      queryParams.themes,
+      queryParams.subjectIds,
     );
   }
   if (queryParams.categoryIds) {
     url.searchParams.set(
       "query[bool][must][][term][category_ids][value]",
-      queryParams.themes,
+      queryParams.categoryIds,
     );
   }
   return url;

--- a/src/utils.js
+++ b/src/utils.js
@@ -20,3 +20,43 @@ export function iiifUrl(
 ) {
   return `${base}/${id}/${size}/${fit && "!"}${width},${height}/0/default.jpg`;
 }
+
+/**
+ * @typedef {Object} QueryParams
+ * @property {string} keywords - Search keywords
+ * @property {string[]} - Themes
+ */
+
+/**
+ * createSearchURL
+ * Takes a QueryParams object and returns a URL object
+ * @param {QueryParams} queryParams - QueryParams object with keywords and/or themes
+ * @returns {URL} - URL object for API query
+ */
+export function createSearchURL(queryParams) {
+  // Build the query string
+  // I've broken this up to make it easer to reason about and manipulate
+  const url = new URL("https://api.artic.edu/api/v1/artworks/search");
+  url.searchParams.set("query[bool][must][][term][is_on_view]", "true");
+  url.searchParams.set("query[bool][must][][exists][field]", "description");
+  url.searchParams.set("query[bool][should][][exists][field]", "description");
+  url.searchParams.set("query[bool][should][][exists][field]", "subject_id");
+  url.searchParams.set("query[bool][should][][exists][field]", "style_id");
+  url.searchParams.set("query[bool][should][][term][is_boosted]", "true");
+  url.searchParams.set("query[bool][minimum_should_match]", "1");
+  url.searchParams.set(
+    "fields",
+    "artist_title,description,id,image_id,thumbnail,title",
+  );
+  url.searchParams.set("limit", "10");
+  if (queryParams.keywords) {
+    url.searchParams.set("q", queryParams.keywords);
+  }
+  if (queryParams.themes) {
+    url.searchParams.set(
+      "query[bool][must][][terms][subject_ids][]",
+      queryParams.themes,
+    );
+  }
+  return url;
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -33,7 +33,7 @@ export function iiifUrl(
  * @param {QueryParams} queryParams - QueryParams object with keywords and/or themes
  * @returns {URL} - URL object for API query
  */
-export function createSearchURL(queryParams) {
+export function createSearchUrl(queryParams) {
   // Build the query string
   // I've broken this up to make it easer to reason about and manipulate
   const url = new URL("https://api.artic.edu/api/v1/artworks/search");


### PR DESCRIPTION
- **Pivotal ticket**: [#186172110](https://www.pivotaltracker.com/story/show/186172110)

# What does this Pull Request do?

This adds buttons which can be used to perform searches for pre-defined search queries or "themes". In practice these are searching on `subject_ids` and `category_ids`. It hooks into the existing `SearchContext` and uses `SearchResults` and `SearchResultItems`, and shares the actual searching logic with `SearchBar`

# Workflow

- [x] Before merging: After all review changes I've synchronised `develop` and rebased this branch on top of it